### PR TITLE
Represent data using pandas data frames

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,9 +2,9 @@ name: Run unit tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   run_tests:
@@ -12,17 +12,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-    - name: Check out main
-      uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install packages
-      run: |
-        python -m pip install . pytest
-    - name: Run pytest
-      run: |
-        pytest
+      - name: Check out main
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install packages
+        run: |
+          python -m pip install . pytest
+      - name: Run pytest
+        run: |
+          pytest

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -1,9 +1,9 @@
 import abc
 import logging
-import time
 from collections import OrderedDict, defaultdict
 from enum import Enum
 from queue import PriorityQueue
+from time import perf_counter
 from typing import Callable, Dict, Iterable, Iterator, List, Sequence, Set, Tuple, Union
 
 import numpy as np
@@ -284,7 +284,7 @@ class Index(abc.ABC):
         if early_stopping and cutoff is None:
             raise ValueError("A cut-off depth is required for early stopping.")
 
-        t0 = time.time()
+        t0 = perf_counter()
 
         # batch encode queries
         q_id_list = list(ranking)
@@ -328,7 +328,7 @@ class Index(abc.ABC):
                 result[a] = Ranking(run, sort=True)
                 result[a].cut(cutoff)
 
-        LOGGER.info(f"computed scores in {time.time() - t0}s")
+        LOGGER.info(f"computed scores in {perf_counter() - t0}s")
         return result
 
 

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -237,11 +237,14 @@ class Index(abc.ABC):
 
         Returns:
             Ranking: The updated ranking.
+
+        Raises:
+            ValueError: When the ranking has no queries attached.
         """
+        if not ranking.has_queries:
+            raise ValueError("Input ranking has no queries attached")
+
         t0 = perf_counter()
-
-        # TODO: error when no queries
-
         new_df = ranking._df.copy(deep=False)
 
         # map doc/passage IDs to unique numbers (0 to n)

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -1,12 +1,10 @@
 import abc
 import logging
 from enum import Enum
-from queue import PriorityQueue
 from time import perf_counter
-from typing import Callable, Dict, Iterable, List, Sequence, Set, Tuple, Union
+from typing import Callable, Iterable, List, Sequence, Set, Tuple, Union
 
 import numpy as np
-import pandas as pd
 from scipy.spatial.distance import cosine
 from tqdm import tqdm
 
@@ -359,50 +357,3 @@ def create_coalesced_index(
         target_index.add(np.array(vectors), doc_ids=doc_ids)
 
     assert source_index.doc_ids == target_index.doc_ids
-
-
-def _interpolate_early_stopping(
-    ids: Iterable[str],
-    dense_scores: Iterable[float],
-    sparse_scores: Iterable[float],
-    alpha: float,
-    cutoff: int,
-) -> Dict[str, float]:
-    """Interpolate scores with early stopping.
-
-    Args:
-        ids (Iterable[str]): Document/passage IDs.
-        dense_scores (Iterable[float]): Corresponding dense scores.
-        sparse_scores (Iterable[float]): Corresponding sparse scores.
-        alpha (float): Interpolation parameter.
-        cutoff (int): Cut-off depth.
-
-    Returns:
-        Dict[str, float]: Document/passage IDs mapped to scores.
-    """
-    result = {}
-    relevant_scores = PriorityQueue(cutoff)
-    min_relevant_score = float("-inf")
-    max_dense_score = float("-inf")
-    for id, dense_score, sparse_score in zip(ids, dense_scores, sparse_scores):
-        if relevant_scores.qsize() >= cutoff:
-
-            # check if approximated max possible score is too low to make a difference
-            min_relevant_score = relevant_scores.get_nowait()
-            max_possible_score = alpha * sparse_score + (1 - alpha) * max_dense_score
-
-            # early stopping
-            if max_possible_score <= min_relevant_score:
-                break
-
-        if dense_score is None:
-            LOGGER.warning(f"{id} not indexed, skipping")
-            continue
-
-        max_dense_score = max(max_dense_score, dense_score)
-        score = alpha * sparse_score + (1 - alpha) * dense_score
-        result[id] = score
-
-        # the new score might be ranked higher than the one we removed
-        relevant_scores.put_nowait(max(score, min_relevant_score))
-    return result

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -325,7 +325,7 @@ class Index(abc.ABC):
                     )
                     for id, score in scores.items():
                         run[q_id][id] = score
-                result[a] = Ranking(run, sort=True, copy=False)
+                result[a] = Ranking(run, sort=True)
                 result[a].cut(cutoff)
 
         LOGGER.info(f"computed scores in {time.time() - t0}s")

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -287,8 +287,14 @@ class Index(abc.ABC):
         else:
             op = lambda x: x[0]
 
+        def _mapfunc(i):
+            scores_i = select_scores[i]
+            if len(scores_i) == 0:
+                return np.nan
+            return op(scores[select_scores[i]])
+
         # insert FF scores in the correct rows
-        new_df["ff_score"] = new_df.index.map(lambda i: op(scores[select_scores[i]]))
+        new_df["ff_score"] = new_df.index.map(_mapfunc)
 
         LOGGER.info(f"computed scores in {perf_counter() - t0}s")
         return Ranking(

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -1,17 +1,17 @@
 import abc
 import logging
-from collections import OrderedDict, defaultdict
 from enum import Enum
 from queue import PriorityQueue
 from time import perf_counter
-from typing import Callable, Dict, Iterable, Iterator, List, Sequence, Set, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Sequence, Set, Tuple, Union
 
 import numpy as np
+import pandas as pd
 from scipy.spatial.distance import cosine
 from tqdm import tqdm
 
 from fast_forward.encoder import QueryEncoder
-from fast_forward.ranking import Ranking, interpolate
+from fast_forward.ranking import Ranking
 
 LOGGER = logging.getLogger(__name__)
 
@@ -39,14 +39,14 @@ class Index(abc.ABC):
         Args:
             encoder (QueryEncoder, optional): The query encoder to use. Defaults to None.
             mode (Mode, optional): Indexing mode. Defaults to Mode.PASSAGE.
-            encoder_batch_size (int, optional): Query encoder batch size. Defaults to 32.
+            encoder_batch_size (int, optional): Encoder batch size. Defaults to 32.
         """
         super().__init__()
-        self.encoder = encoder
+        self.query_encoder = encoder
         self.mode = mode
         self._encoder_batch_size = encoder_batch_size
 
-    def encode(self, queries: Sequence[str]) -> List[np.ndarray]:
+    def encode_queries(self, queries: Sequence[str]) -> np.ndarray:
         """Encode queries.
 
         Args:
@@ -56,35 +56,35 @@ class Index(abc.ABC):
             RuntimeError: When no query encoder exists.
 
         Returns:
-            List[np.ndarray]: The query representations.
+            np.ndarray: The query representations.
         """
-        if self._encoder is None:
+        if self._query_encoder is None:
             raise RuntimeError("This index does not have a query encoder.")
 
         result = []
         for i in range(0, len(queries), self._encoder_batch_size):
             batch = queries[i : i + self._encoder_batch_size]
-            result.extend(self._encoder.encode(batch))
-        return result
+            result.append(self._query_encoder.encode(batch))
+        return np.concatenate(result)
 
     @property
-    def encoder(self) -> QueryEncoder:
+    def query_encoder(self) -> QueryEncoder:
         """Return the query encoder.
 
         Returns:
             QueryEncoder: The encoder.
         """
-        return self._encoder
+        return self._query_encoder
 
-    @encoder.setter
-    def encoder(self, encoder: QueryEncoder) -> None:
+    @query_encoder.setter
+    def query_encoder(self, encoder: QueryEncoder) -> None:
         """Set the query encoder.
 
         Args:
             encoder (QueryEncoder): The encoder.
         """
         assert encoder is None or isinstance(encoder, QueryEncoder)
-        self._encoder = encoder
+        self._query_encoder = encoder
 
     @property
     def mode(self) -> Mode:
@@ -231,105 +231,73 @@ class Index(abc.ABC):
         """
         pass
 
-    def _compute_scores(self, q_rep: np.ndarray, ids: Iterable[str]) -> Iterator[float]:
-        """Compute scores based on the current mode.
+    def __call__(self, ranking: Ranking) -> Ranking:
+        """Compute scores for a ranking.
 
         Args:
-            q_rep (np.ndarray): Query representation.
-            ids (Iterable[str]): Document/passage IDs.
-
-        Yields:
-            float: The scores, preserving the order of the IDs.
-        """
-        vectors, id_indices = self._get_vectors(ids)
-        all_scores = np.dot(q_rep, vectors.T)
-
-        for ind in id_indices:
-            if len(ind) == 0:
-                yield None
-            else:
-                if self.mode == Mode.MAXP:
-                    yield np.max(all_scores[ind])
-                elif self.mode == Mode.AVEP:
-                    yield np.average(all_scores[ind])
-                elif self.mode in (Mode.FIRSTP, Mode.PASSAGE):
-                    yield all_scores[ind][0]
-
-    def get_scores(
-        self,
-        ranking: Ranking,
-        queries: Dict[str, str],
-        alpha: Union[float, Iterable[float]] = 0.0,
-        cutoff: int = None,
-        early_stopping: bool = False,
-    ) -> Dict[float, Ranking]:
-        """Compute corresponding dense scores for a ranking and interpolate.
-
-        Args:
-            ranking (Ranking): The ranking to compute scores for and interpolate with.
-            queries (Dict[str, str]): Query IDs mapped to queries.
-            alpha (Union[float, Iterable[float]], optional): Interpolation weight(s). Defaults to 0.0.
-            cutoff (int, optional): Cut-off depth (documents/passages per query). Defaults to None.
-            early_stopping (bool, optional): Whether to use early stopping. Defaults to False.
-
-        Raises:
-            ValueError: When the cut-off depth is missing for early stopping.
+            ranking (Ranking): The ranking to compute scores for. Must have queries attached.
 
         Returns:
-            Dict[float, Ranking]: Alpha mapped to interpolated scores.
+            Ranking: The updated ranking.
         """
-        if isinstance(alpha, float):
-            alpha = [alpha]
-
-        if early_stopping and cutoff is None:
-            raise ValueError("A cut-off depth is required for early stopping.")
-
         t0 = perf_counter()
 
+        # TODO: error when no queries
+
+        new_df = ranking._df.copy(deep=False)
+
+        # map doc/passage IDs to unique numbers (0 to n)
+        id_df = new_df[["id"]].drop_duplicates().reset_index(drop=True)
+        id_df["id_no"] = id_df.index
+        new_df = new_df.merge(id_df, on="id", suffixes=[None, "_"])
+
+        # get all unique queries and query IDs and map to unique numbers (0 to m)
+        query_df = new_df[["q_id", "query"]].drop_duplicates().reset_index(drop=True)
+        query_df["q_no"] = query_df.index
+        new_df = new_df.merge(query_df, on="q_id", suffixes=[None, "_"])
+
         # batch encode queries
-        q_id_list = list(ranking)
-        q_reps = self.encode([queries[q_id] for q_id in q_id_list])
+        query_vectors = self.encode_queries(list(query_df["query"]))
 
-        result = {}
-        if not early_stopping:
-            # here we can simply compute the dense scores once and interpolate for each alpha
-            dense_run = defaultdict(OrderedDict)
-            for q_id, q_rep in zip(tqdm(q_id_list), q_reps):
-                ids = list(ranking[q_id].keys())
-                for id, score in zip(ids, self._compute_scores(q_rep, ids)):
-                    if score is None:
-                        LOGGER.warning(f"{id} not indexed, skipping")
-                    else:
-                        dense_run[q_id][id] = score
-            for a in alpha:
-                result[a] = interpolate(
-                    ranking, Ranking(dense_run, sort=False), a, sort=True
-                )
-                if cutoff is not None:
-                    result[a].cut(cutoff)
+        # get all required vectors from the FF index
+        vectors, id_to_vec_idxs = self._get_vectors(id_df["id"].to_list())
+
+        # compute indices for query vectors and doc/passage vectors in current arrays
+        select_query_vectors = []
+        select_vectors = []
+        select_scores = []
+        c = 0
+        for id_no, q_no in zip(new_df["id_no"], new_df["q_no"]):
+            vec_idxs = id_to_vec_idxs[id_no]
+            select_vectors.extend(vec_idxs)
+            select_scores.append(list(range(c, c + len(vec_idxs))))
+            c += len(vec_idxs)
+            select_query_vectors.extend([q_no] * len(vec_idxs))
+
+        # compute all dot products (scores)
+        q_reps = query_vectors[select_query_vectors]
+        d_reps = vectors[select_vectors]
+        scores = np.sum(q_reps * d_reps, axis=1)
+
+        # select aggregation operation based on current mode
+        if self.mode == Mode.MAXP:
+            op = np.max
+        elif self.mode == Mode.AVEP:
+            op = np.average
         else:
-            # early stopping requries the ranking to be sorted
-            # this should normally be the case anyway
-            if not ranking.is_sorted:
-                LOGGER.warning("input ranking not sorted. sorting...")
-                ranking.sort()
+            op = lambda x: x[0]
 
-            # since early stopping depends on alpha, we have to run the algorithm more than once
-            for a in alpha:
-                run = defaultdict(OrderedDict)
-                for q_id, q_rep in zip(tqdm(q_id_list), q_reps):
-                    ids, sparse_scores = zip(*ranking[q_id].items())
-                    dense_scores = self._compute_scores(q_rep, ids)
-                    scores = _interpolate_early_stopping(
-                        ids, dense_scores, sparse_scores, a, cutoff
-                    )
-                    for id, score in scores.items():
-                        run[q_id][id] = score
-                result[a] = Ranking(run, sort=True)
-                result[a].cut(cutoff)
+        # insert FF scores in the correct rows
+        new_df["ff_score"] = new_df.index.map(lambda i: op(scores[select_scores[i]]))
 
         LOGGER.info(f"computed scores in {perf_counter() - t0}s")
-        return result
+        return Ranking(
+            new_df,
+            name=ranking.name,
+            dtype=ranking._df.dtypes["score"],
+            copy=False,
+            is_sorted=True,
+        )
 
 
 def create_coalesced_index(

--- a/fast_forward/index/disk.py
+++ b/fast_forward/index/disk.py
@@ -270,7 +270,10 @@ class OnDiskIndex(Index):
         with h5py.File(index._index_file, "r") as fp:
             for i, (doc_id, psg_id) in tqdm(
                 enumerate(
-                    zip(fp["doc_ids"].asstr()[:], fp["psg_ids"].asstr()[:]),
+                    zip(
+                        fp["doc_ids"].asstr()[: fp.attrs["num_vectors"]],
+                        fp["psg_ids"].asstr()[: fp.attrs["num_vectors"]],
+                    ),
                 ),
                 total=fp.attrs["num_vectors"],
             ):

--- a/fast_forward/index/disk.py
+++ b/fast_forward/index/disk.py
@@ -22,7 +22,7 @@ class OnDiskIndex(Index):
         self,
         index_file: Path,
         dim: int,
-        encoder: QueryEncoder = None,
+        query_encoder: QueryEncoder = None,
         mode: Mode = Mode.PASSAGE,
         encoder_batch_size: int = 32,
         init_size: int = 2**14,
@@ -37,7 +37,7 @@ class OnDiskIndex(Index):
         Args:
             index_file (Path): Index file to create (or overwrite).
             dim (int): Vector dimension.
-            encoder (QueryEncoder, optional): Query encoder. Defaults to None.
+            query_encoder (QueryEncoder, optional): Query encoder. Defaults to None.
             mode (Mode, optional): Ranking mode. Defaults to Mode.PASSAGE.
             encoder_batch_size (int, optional): Batch size for query encoder. Defaults to 32.
             init_size (int, optional): Initial size to allocate (number of vectors). Defaults to 2**14.
@@ -53,7 +53,7 @@ class OnDiskIndex(Index):
         if index_file.exists() and not overwrite:
             raise ValueError(f"File {index_file} exists")
 
-        super().__init__(encoder, mode, encoder_batch_size)
+        super().__init__(query_encoder, mode, encoder_batch_size)
         self._index_file = index_file.absolute()
         self._resize_min_val = resize_min_val
         self._doc_id_to_idx = defaultdict(list)
@@ -105,7 +105,7 @@ class OnDiskIndex(Index):
         with h5py.File(self._index_file, "r") as fp:
             index = InMemoryIndex(
                 dim=self.dim,
-                encoder=self._encoder,
+                query_encoder=self._query_encoder,
                 mode=self.mode,
                 encoder_batch_size=self._encoder_batch_size,
                 init_size=len(self),

--- a/fast_forward/index/memory.py
+++ b/fast_forward/index/memory.py
@@ -16,7 +16,7 @@ class InMemoryIndex(Index):
     def __init__(
         self,
         dim: int,
-        encoder: QueryEncoder = None,
+        query_encoder: QueryEncoder = None,
         mode: Mode = Mode.PASSAGE,
         encoder_batch_size: int = 32,
         init_size: int = 2**14,
@@ -27,7 +27,7 @@ class InMemoryIndex(Index):
 
         Args:
             dim (int): Vector dimension.
-            encoder (QueryEncoder, optional): The query encoder to use. Defaults to None.
+            query_encoder (QueryEncoder, optional): The query encoder to use. Defaults to None.
             mode (Mode, optional): Indexing mode. Defaults to Mode.PASSAGE.
             encoder_batch_size (int, optional): Query encoder batch size. Defaults to 32.
             init_size (int, optional): Initial index size. Defaults to 2**14.
@@ -42,7 +42,7 @@ class InMemoryIndex(Index):
         self._dim = dim
         self._doc_id_to_idx = defaultdict(list)
         self._psg_id_to_idx = {}
-        super().__init__(encoder, mode, encoder_batch_size)
+        super().__init__(query_encoder, mode, encoder_batch_size)
 
     def __len__(self) -> int:
         # account for the fact that the first shard might be larger

--- a/fast_forward/ranking.py
+++ b/fast_forward/ranking.py
@@ -59,7 +59,7 @@ class Ranking(object):
         """
         if not self.is_sorted:
             self.sort()
-        self._df = self._df.groupby("q_id").head(2).reset_index(drop=True)
+        self._df = self._df.groupby("q_id").head(cutoff).reset_index(drop=True)
 
     def __getitem__(self, q_id: str) -> Dict[str, float]:
         """Return the ranking for a query.

--- a/fast_forward/ranking.py
+++ b/fast_forward/ranking.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Iterator, Union
+from typing import Dict, Iterator, Set, Union
 
 import numpy as np
 import pandas as pd
@@ -37,7 +37,15 @@ class Ranking(object):
         if sort:
             self.sort()
         self._q_ids = set(pd.unique(self._df["q_id"]))
-        self.q_ids = self._q_ids
+
+    @property
+    def q_ids(self) -> Set[str]:
+        """The set of (unique) query IDs in this ranking. Only queries with at least one scored document are considered.
+
+        Returns:
+            Set[str]: The query IDs.
+        """
+        return self._q_ids
 
     def sort(self) -> None:
         """Sort the ranking by scores (in-place)."""

--- a/fast_forward/ranking.py
+++ b/fast_forward/ranking.py
@@ -51,6 +51,15 @@ class Ranking(object):
         self._df.reset_index(inplace=True, drop=True)
 
     @property
+    def has_queries(self) -> bool:
+        """Whether the ranking has queries attached.
+
+        Returns:
+            bool: Whether queries exist.
+        """
+        return "query" in self._df.columns
+
+    @property
     def q_ids(self) -> Set[str]:
         """The set of (unique) query IDs in this ranking. Only queries with at least one scored document are considered.
 

--- a/fast_forward/ranking.py
+++ b/fast_forward/ranking.py
@@ -44,9 +44,14 @@ class Ranking(object):
         else:
             self._df = df.loc[:, cols]
 
-        self._df["score"] = self._df["score"].astype(dtype)
-        if "ff_score" in df.columns:
-            self._df["ff_score"] = self._df["ff_score"].astype(dtype)
+        for col, dt in (
+            ("score", dtype),
+            ("ff_score", dtype),
+            ("q_id", str),
+            ("id", str),
+        ):
+            if col in self._df.columns and self._df[col].dtype != dt:
+                self._df[col] = self._df[col].astype(dt)
 
         self._q_ids = set(pd.unique(self._df["q_id"]))
 
@@ -186,7 +191,7 @@ class Ranking(object):
     def interpolate(
         self, alpha: float, cutoff: int = None, early_stopping: bool = False
     ) -> "Ranking":
-        """Interpolate scores as `score * alpha + ff_score * (1 - alpha)`
+        """Interpolate as `score = score * alpha + ff_score * (1 - alpha)`.
 
         Args:
             alpha (float): Interpolation parameter.

--- a/fast_forward/ranking.py
+++ b/fast_forward/ranking.py
@@ -16,8 +16,7 @@ class Ranking(object):
         run: Run,
         name: str = None,
         sort: bool = True,
-        copy=False,
-        score_dtype: np.dtype = np.float32,
+        dtype: np.dtype = np.float32,
     ) -> None:
         """Constructor.
 
@@ -25,15 +24,14 @@ class Ranking(object):
             run (Run): Run to create ranking from.
             name (str, optional): Method name. Defaults to None.
             sort (bool, optional): Whether to sort the documents/passages by score. Defaults to True.
-            copy (bool, optional): Unused parameter. Defaults to False.
-            sort (score_dtype, np.dtype): How the score should be represented in the data frame. Defaults to np.float32.
+            dtype (np.dtype, optional): How the score should be represented in the data frame. Defaults to np.float32.
         """
         super().__init__()
         self.name = name
         self.is_sorted = sort
         self._df = pd.DataFrame.from_dict(run).stack().reset_index()
         self._df.columns = ("id", "q_id", "score")
-        self._df["score"] = self._df["score"].astype(score_dtype)
+        self._df["score"] = self._df["score"].astype(dtype)
         if sort:
             self.sort()
         self._q_ids = set(pd.unique(self._df["q_id"]))
@@ -187,4 +185,4 @@ def interpolate(
             results[q_id][doc_id] = (
                 alpha * r1[q_id][doc_id] + (1 - alpha) * r2[q_id][doc_id]
             )
-    return Ranking(results, name=name, sort=sort, copy=False)
+    return Ranking(results, name=name, sort=sort)

--- a/fast_forward/ranking.py
+++ b/fast_forward/ranking.py
@@ -60,6 +60,15 @@ class Ranking(object):
         return "query" in self._df.columns
 
     @property
+    def has_ff_scores(self) -> bool:
+        """Whether the ranking has semantic scores.
+
+        Returns:
+            bool: Whether semantic scores exist.
+        """
+        return "ff_score" in self._df.columns
+
+    @property
     def q_ids(self) -> Set[str]:
         """The set of (unique) query IDs in this ranking. Only queries with at least one scored document are considered.
 
@@ -134,9 +143,19 @@ class Ranking(object):
         Returns:
             bool: Whether the two rankings are identical.
         """
-        return self._df.set_index(["q_id", "id"])["score"].equals(
+        if not isinstance(o, Ranking) or self.has_ff_scores != o.has_ff_scores:
+            return False
+
+        score_eq = self._df.set_index(["q_id", "id"])["score"].equals(
             o._df.set_index(["q_id", "id"])["score"]
         )
+        if self.has_ff_scores:
+            ff_score_eq = self._df.set_index(["q_id", "id"])["ff_score"].equals(
+                o._df.set_index(["q_id", "id"])["ff_score"]
+            )
+        else:
+            ff_score_eq = True
+        return score_eq and ff_score_eq
 
     def __repr__(self) -> str:
         """Return the run a string representation of this ranking.

--- a/fast_forward/ranking.py
+++ b/fast_forward/ranking.py
@@ -135,16 +135,14 @@ class Ranking(object):
         if not isinstance(o, Ranking) or self.has_ff_scores != o.has_ff_scores:
             return False
 
-        score_eq = self._df.set_index(["q_id", "id"])["score"].equals(
-            o._df.set_index(["q_id", "id"])["score"]
-        )
+        df1 = self._df.sort_values(["q_id", "id"]).reset_index(drop=True)
+        df2 = o._df.sort_values(["q_id", "id"]).reset_index(drop=True)
+
+        cols = ["q_id", "id", "score"]
         if self.has_ff_scores:
-            ff_score_eq = self._df.set_index(["q_id", "id"])["ff_score"].equals(
-                o._df.set_index(["q_id", "id"])["ff_score"]
-            )
-        else:
-            ff_score_eq = True
-        return score_eq and ff_score_eq
+            cols += ["ff_score"]
+
+        return df1[cols].equals(df2[cols])
 
     def __repr__(self) -> str:
         """Return the run a string representation of this ranking.

--- a/fast_forward/ranking.py
+++ b/fast_forward/ranking.py
@@ -48,6 +48,7 @@ class Ranking(object):
     def sort(self) -> None:
         """Sort the ranking by scores (in-place)."""
         self._df.sort_values(by=["q_id", "score"], inplace=True, ascending=False)
+        self._df.reset_index(inplace=True, drop=True)
         self.is_sorted = True
 
     def cut(self, cutoff: int) -> None:
@@ -58,7 +59,7 @@ class Ranking(object):
         """
         if not self.is_sorted:
             self.sort()
-        self._df = self._df.groupby("q_id").head(2)
+        self._df = self._df.groupby("q_id").head(2).reset_index(drop=True)
 
     def __getitem__(self, q_id: str) -> Dict[str, float]:
         """Return the ranking for a query.

--- a/fast_forward/ranking.py
+++ b/fast_forward/ranking.py
@@ -45,6 +45,17 @@ class Ranking(object):
         """
         return self._q_ids
 
+    def attach_queries(self, queries: Dict[str, str]) -> None:
+        """Attach queries to this ranking (in-place).
+
+        Args:
+            queries (Dict[str, str]): Query IDs mapped to queries.
+        """
+        if set(queries.keys()) != self._q_ids:
+            raise ValueError("Queries are incomplete")
+        q_df = pd.DataFrame(queries.items(), columns=["q_id", "query"])
+        self._df = self._df.merge(q_df, how="left", on="q_id")
+
     def sort(self) -> None:
         """Sort the ranking by scores (in-place)."""
         self._df.sort_values(by=["q_id", "score"], inplace=True, ascending=False)
@@ -100,7 +111,7 @@ class Ranking(object):
         return key in self._q_ids
 
     def __eq__(self, o: object) -> bool:
-        """Check if this ranking is identical to another one.
+        """Check if this ranking is identical to another one. Only takes IDs and scores into account.
 
         Args:
             o (object): The other ranking.

--- a/fast_forward/ranking.py
+++ b/fast_forward/ranking.py
@@ -15,6 +15,7 @@ class Ranking(object):
         self,
         df: pd.DataFrame,
         name: str = None,
+        queries: Dict[str, str] = None,
         dtype: np.dtype = np.float32,
         copy: bool = True,
         is_sorted: bool = False,
@@ -23,7 +24,8 @@ class Ranking(object):
 
         Args:
             df (pd.DataFrame): Data frame containing IDs and scores.
-            name (str, optional): Method name. Defaults to None. Defaults to True.
+            name (str, optional): Method name. Defaults to None. Defaults to None.
+            queries (Dict[str, str], optional): Query IDs mapped to queries. Defaults to None.
             dtype (np.dtype, optional): How the scores should be represented in the data frame. Defaults to np.float32.
             copy (bool, optional): Whether to copy the data frame. Defaults to True.
             is_sorted (bool, optional): Whether the data frame is already sorted (by score). Defaults to False.
@@ -47,6 +49,9 @@ class Ranking(object):
 
         if not is_sorted:
             self._sort()
+
+        if queries is not None:
+            self.attach_queries(queries)
 
     def _sort(self) -> None:
         """Sort the ranking by scores (in-place)."""
@@ -219,12 +224,18 @@ class Ranking(object):
 
     @classmethod
     def from_run(
-        cls, run: Run, name: str = None, dtype: np.dtype = np.float32
+        cls,
+        run: Run,
+        name: str = None,
+        queries: Dict[str, str] = None,
+        dtype: np.dtype = np.float32,
     ) -> "Ranking":
         """Create a Ranking object from a TREC run.
 
         Args:
             run (Run): TREC run.
+            name (str, optional): Method name. Defaults to None. Defaults to None.
+            queries (Dict[str, str], optional): Query IDs mapped to queries. Defaults to None.
             dtype (np.dtype, optional): How the score should be represented in the data frame. Defaults to np.float32.
 
         Returns:
@@ -232,14 +243,20 @@ class Ranking(object):
         """
         df = pd.DataFrame.from_dict(run).stack().reset_index()
         df.columns = ("id", "q_id", "score")
-        return cls(df, name=name, dtype=dtype, copy=False)
+        return cls(df, name=name, queries=queries, dtype=dtype, copy=False)
 
     @classmethod
-    def from_file(cls, f: Path, dtype: np.dtype = np.float32) -> "Ranking":
+    def from_file(
+        cls,
+        f: Path,
+        queries: Dict[str, str] = None,
+        dtype: np.dtype = np.float32,
+    ) -> "Ranking":
         """Create a Ranking object from a runfile in TREC format.
 
         Args:
             f (Path): TREC runfile to read.
+            queries (Dict[str, str], optional): Query IDs mapped to queries. Defaults to None.
             dtype (np.dtype, optional): How the score should be represented in the data frame. Defaults to np.float32.
 
         Returns:
@@ -252,4 +269,4 @@ class Ranking(object):
             header=None,
             names=["q_id", "q0", "id", "rank", "score", "name"],
         )
-        return cls(df, name=df["name"][0], dtype=dtype, copy=False)
+        return cls(df, name=df["name"][0], queries=queries, dtype=dtype, copy=False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ python_requires = >=3.7
 install_requires =
     torch >=1.8.2
     numpy >=1.20.3
+    pandas >=2.0.3
     transformers >=4.9.0
     scipy >=1.7.3
     tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 package_dir =
     = .
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     torch >=1.8.2
     numpy >=1.20.3

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -182,6 +182,9 @@ class TestIndex(unittest.TestCase):
             self.index_wrong_dim.add(
                 DUMMY_VECTORS, doc_ids=DUMMY_DOC_IDS, psg_ids=DUMMY_PSG_IDS
             )
+        ranking_no_queries = Ranking.from_run(DUMMY_DOC_RUN)
+        with self.assertRaises(ValueError):
+            self.doc_psg_index(ranking_no_queries)
 
     def test_coalescing(self):
         # delta = 0.3: vectors of d0 should be averaged

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -113,24 +113,6 @@ class TestIndex(unittest.TestCase):
                 }
             ),
         )
-        self.assertEqual(
-            result.interpolate(0.5),
-            Ranking.from_run(
-                {
-                    "q1": {"d0": 51, "d1": 2.5, "d2": 3.5, "d3": 102.5},
-                    "q2": {"d0": 201, "d1": 4, "d2": 5, "d3": 402.5},
-                }
-            ),
-        )
-        self.assertEqual(
-            result.interpolate(1.0),
-            Ranking.from_run(
-                {
-                    "q1": {"d0": 100, "d1": 2, "d2": 3, "d3": 200},
-                    "q2": {"d0": 400, "d1": 5, "d2": 6, "d3": 800},
-                }
-            ),
-        )
 
     def test_firstp(self):
         expected = Ranking.from_run(
@@ -154,7 +136,7 @@ class TestIndex(unittest.TestCase):
         expected = Ranking.from_run(
             {
                 "q1": {"d0": 1.5, "d1": 3, "d2": 4, "d3": 5},
-                "q2": {"d0": 1.5, "d1": 3, "d2": 4, "d3": 5, "dx": np.nan},
+                "q2": {"d0": 1.5, "d1": 3, "d2": 4, "d3": 5},
             }
         )
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -101,7 +101,7 @@ class TestIndex(unittest.TestCase):
                 idxs,
             )
 
-    def test_interpolation(self):
+    def test_maxp(self):
         self.doc_psg_index.mode = Mode.MAXP
         result = self.doc_psg_index(DUMMY_DOC_RANKING)
         self.assertEqual(

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -27,12 +27,12 @@ DUMMY_DOC_RUN = {
     "q1": {"d0": 100, "d1": 2, "d2": 3, "d3": 200},
     "q2": {"d0": 400, "d1": 5, "d2": 6, "d3": 800, "dx": 7},
 }
-DUMMY_DOC_RANKING = Ranking(DUMMY_DOC_RUN)
+DUMMY_DOC_RANKING = Ranking.from_run(DUMMY_DOC_RUN)
 DUMMY_PSG_RUN = {
     "q1": {"p0": 100, "p1": 2, "p2": 3, "p3": 4, "p4": 5},
     "q2": {"p0": 500, "p1": 6, "p2": 7, "p3": 8, "p4": 9},
 }
-DUMMY_PSG_RANKING = Ranking(DUMMY_PSG_RUN)
+DUMMY_PSG_RANKING = Ranking.from_run(DUMMY_PSG_RUN)
 DUMMY_ENCODER = LambdaQueryEncoder(lambda _: np.array([1, 1, 1, 1, 1]))
 
 
@@ -112,7 +112,7 @@ class TestIndex(unittest.TestCase):
         )
         self.assertEqual(
             result[0.0],
-            Ranking(
+            Ranking.from_run(
                 {
                     "q1": {"d0": 2, "d1": 3, "d2": 4, "d3": 5},
                     "q2": {"d0": 2, "d1": 3, "d2": 4, "d3": 5},
@@ -121,7 +121,7 @@ class TestIndex(unittest.TestCase):
         )
         self.assertEqual(
             result[0.5],
-            Ranking(
+            Ranking.from_run(
                 {
                     "q1": {"d0": 51, "d1": 2.5, "d2": 3.5, "d3": 102.5},
                     "q2": {"d0": 201, "d1": 4, "d2": 5, "d3": 402.5},
@@ -130,7 +130,7 @@ class TestIndex(unittest.TestCase):
         )
         self.assertEqual(
             result[1.0],
-            Ranking(
+            Ranking.from_run(
                 {
                     "q1": {"d0": 100, "d1": 2, "d2": 3, "d3": 200},
                     "q2": {"d0": 400, "d1": 5, "d2": 6, "d3": 800},
@@ -149,18 +149,11 @@ class TestIndex(unittest.TestCase):
             early_stopping=True,
         )
 
-        # test unsorted ranking
-        scores_2 = self.doc_psg_index.get_scores(
-            Ranking(DUMMY_DOC_RUN, sort=False),
-            DUMMY_QUERIES,
-            alpha=0.5,
-            cutoff=2,
-            early_stopping=True,
-        )
-
         self.assertEqual(
             scores_1[0.5],
-            Ranking({"q1": {"d3": 102.5, "d0": 51}, "q2": {"d3": 402.5, "d0": 201}}),
+            Ranking.from_run(
+                {"q1": {"d3": 102.5, "d0": 51}, "q2": {"d3": 402.5, "d0": 201}}
+            ),
         )
         self.assertEqual(scores_1[0.5], scores_2[0.5])
 
@@ -174,7 +167,7 @@ class TestIndex(unittest.TestCase):
             )
 
     def test_firstp(self):
-        expected = Ranking(
+        expected = Ranking.from_run(
             {
                 "q1": {"d0": 1, "d1": 3, "d2": 4, "d3": 5},
                 "q2": {"d0": 1, "d1": 3, "d2": 4, "d3": 5},
@@ -192,7 +185,7 @@ class TestIndex(unittest.TestCase):
         )
 
     def test_avep(self):
-        expected = Ranking(
+        expected = Ranking.from_run(
             {
                 "q1": {"d0": 1.5, "d1": 3, "d2": 4, "d3": 5},
                 "q2": {"d0": 1.5, "d1": 3, "d2": 4, "d3": 5},
@@ -210,7 +203,7 @@ class TestIndex(unittest.TestCase):
         )
 
     def test_passage(self):
-        expected = Ranking(
+        expected = Ranking.from_run(
             {
                 "q1": {"p0": 1, "p1": 2, "p2": 3, "p3": 4, "p4": 5},
                 "q2": {"p0": 1, "p1": 2, "p2": 3, "p3": 4, "p4": 5},

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -27,12 +27,12 @@ DUMMY_DOC_RUN = {
     "q1": {"d0": 100, "d1": 2, "d2": 3, "d3": 200},
     "q2": {"d0": 400, "d1": 5, "d2": 6, "d3": 800, "dx": 7},
 }
-DUMMY_DOC_RANKING = Ranking.from_run(DUMMY_DOC_RUN)
+DUMMY_DOC_RANKING = Ranking.from_run(DUMMY_DOC_RUN, queries=DUMMY_QUERIES)
 DUMMY_PSG_RUN = {
     "q1": {"p0": 100, "p1": 2, "p2": 3, "p3": 4, "p4": 5},
     "q2": {"p0": 500, "p1": 6, "p2": 7, "p3": 8, "p4": 9},
 }
-DUMMY_PSG_RANKING = Ranking.from_run(DUMMY_PSG_RUN)
+DUMMY_PSG_RANKING = Ranking.from_run(DUMMY_PSG_RUN, queries=DUMMY_QUERIES)
 DUMMY_ENCODER = LambdaQueryEncoder(lambda _: np.array([1, 1, 1, 1, 1]))
 
 
@@ -103,15 +103,9 @@ class TestIndex(unittest.TestCase):
 
     def test_interpolation(self):
         self.doc_psg_index.mode = Mode.MAXP
-        result = self.doc_psg_index.get_scores(
-            DUMMY_DOC_RANKING,
-            DUMMY_QUERIES,
-            alpha=[0.0, 0.5, 1.0],
-            cutoff=None,
-            early_stopping=False,
-        )
+        result = self.doc_psg_index(DUMMY_DOC_RANKING)
         self.assertEqual(
-            result[0.0],
+            result.interpolate(0.0),
             Ranking.from_run(
                 {
                     "q1": {"d0": 2, "d1": 3, "d2": 4, "d3": 5},
@@ -120,7 +114,7 @@ class TestIndex(unittest.TestCase):
             ),
         )
         self.assertEqual(
-            result[0.5],
+            result.interpolate(0.5),
             Ranking.from_run(
                 {
                     "q1": {"d0": 51, "d1": 2.5, "d2": 3.5, "d3": 102.5},
@@ -129,7 +123,7 @@ class TestIndex(unittest.TestCase):
             ),
         )
         self.assertEqual(
-            result[1.0],
+            result.interpolate(1.0),
             Ranking.from_run(
                 {
                     "q1": {"d0": 100, "d1": 2, "d2": 3, "d3": 200},
@@ -137,34 +131,6 @@ class TestIndex(unittest.TestCase):
                 }
             ),
         )
-
-    def test_early_stopping(self):
-        self.doc_psg_index.mode = Mode.MAXP
-
-        scores_1 = self.doc_psg_index.get_scores(
-            DUMMY_DOC_RANKING,
-            DUMMY_QUERIES,
-            alpha=0.5,
-            cutoff=2,
-            early_stopping=True,
-        )
-
-        self.assertEqual(
-            scores_1[0.5],
-            Ranking.from_run(
-                {"q1": {"d3": 102.5, "d0": 51}, "q2": {"d3": 402.5, "d0": 201}}
-            ),
-        )
-        self.assertEqual(scores_1[0.5], scores_2[0.5])
-
-        with self.assertRaises(ValueError):
-            self.doc_psg_index.get_scores(
-                DUMMY_DOC_RANKING,
-                DUMMY_QUERIES,
-                alpha=0.5,
-                cutoff=None,
-                early_stopping=True,
-            )
 
     def test_firstp(self):
         expected = Ranking.from_run(
@@ -175,12 +141,12 @@ class TestIndex(unittest.TestCase):
         )
         self.doc_psg_index.mode = Mode.FIRSTP
         self.assertEqual(
-            self.doc_psg_index.get_scores(DUMMY_DOC_RANKING, DUMMY_QUERIES)[0.0],
+            self.doc_psg_index(DUMMY_DOC_RANKING).interpolate(0.0),
             expected,
         )
         self.index_partial_ids.mode = Mode.FIRSTP
         self.assertEqual(
-            self.doc_psg_index.get_scores(DUMMY_DOC_RANKING, DUMMY_QUERIES)[0.0],
+            self.doc_psg_index(DUMMY_DOC_RANKING).interpolate(0.0),
             expected,
         )
 
@@ -188,17 +154,20 @@ class TestIndex(unittest.TestCase):
         expected = Ranking.from_run(
             {
                 "q1": {"d0": 1.5, "d1": 3, "d2": 4, "d3": 5},
-                "q2": {"d0": 1.5, "d1": 3, "d2": 4, "d3": 5},
+                "q2": {"d0": 1.5, "d1": 3, "d2": 4, "d3": 5, "dx": np.nan},
             }
         )
+
         self.doc_psg_index.mode = Mode.AVEP
+        print(expected)
+        print(self.doc_psg_index(DUMMY_DOC_RANKING).interpolate(0.0))
         self.assertEqual(
-            self.doc_psg_index.get_scores(DUMMY_DOC_RANKING, DUMMY_QUERIES)[0.0],
+            self.doc_psg_index(DUMMY_DOC_RANKING).interpolate(0.0),
             expected,
         )
         self.index_partial_ids.mode = Mode.AVEP
         self.assertEqual(
-            self.index_partial_ids.get_scores(DUMMY_DOC_RANKING, DUMMY_QUERIES)[0.0],
+            self.index_partial_ids(DUMMY_DOC_RANKING).interpolate(0.0),
             expected,
         )
 
@@ -210,13 +179,15 @@ class TestIndex(unittest.TestCase):
             }
         )
         self.doc_psg_index.mode = Mode.PASSAGE
+        print(self.doc_psg_index(DUMMY_PSG_RANKING).interpolate(0.0))
+        print(expected)
         self.assertEqual(
-            self.doc_psg_index.get_scores(DUMMY_PSG_RANKING, DUMMY_QUERIES)[0.0],
+            self.doc_psg_index(DUMMY_PSG_RANKING).interpolate(0.0),
             expected,
         )
         self.index_partial_ids.mode = Mode.PASSAGE
         self.assertEqual(
-            self.index_partial_ids.get_scores(DUMMY_PSG_RANKING, DUMMY_QUERIES)[0.0],
+            self.index_partial_ids(DUMMY_PSG_RANKING).interpolate(0.0),
             expected,
         )
 
@@ -224,7 +195,7 @@ class TestIndex(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.index_no_enc.add(DUMMY_VECTORS, doc_ids=None, psg_ids=None)
         with self.assertRaises(RuntimeError):
-            self.index_no_enc.encode(["test"])
+            self.index_no_enc.encode_queries(["test"])
         with self.assertRaises(ValueError):
             self.index_wrong_dim.add(
                 DUMMY_VECTORS, doc_ids=DUMMY_DOC_IDS, psg_ids=DUMMY_PSG_IDS
@@ -262,8 +233,8 @@ class TestInMemoryIndex(TestIndex):
         self.index_partial_ids = InMemoryIndex(DUMMY_DIM, DUMMY_ENCODER)
         self.doc_index = InMemoryIndex(DUMMY_DIM, DUMMY_ENCODER)
         self.psg_index = InMemoryIndex(DUMMY_DIM, DUMMY_ENCODER)
-        self.index_no_enc = InMemoryIndex(DUMMY_DIM, encoder=None)
-        self.index_wrong_dim = InMemoryIndex(DUMMY_DIM + 1, encoder=None)
+        self.index_no_enc = InMemoryIndex(DUMMY_DIM, query_encoder=None)
+        self.index_wrong_dim = InMemoryIndex(DUMMY_DIM + 1, query_encoder=None)
         self.coalesced_indexes = [
             InMemoryIndex(DUMMY_DIM, mode=Mode.MAXP),
             InMemoryIndex(DUMMY_DIM, mode=Mode.MAXP),
@@ -315,10 +286,10 @@ class TestOnDiskIndex(TestIndex):
             DUMMY_ENCODER,
         )
         self.index_no_enc = OnDiskIndex(
-            self.temp_dir / "index_no_enc.h5", DUMMY_DIM, encoder=None
+            self.temp_dir / "index_no_enc.h5", DUMMY_DIM, query_encoder=None
         )
         self.index_wrong_dim = OnDiskIndex(
-            self.temp_dir / "index_wrong_dim.h5", DUMMY_DIM + 1, encoder=None
+            self.temp_dir / "index_wrong_dim.h5", DUMMY_DIM + 1, query_encoder=None
         )
         self.coalesced_indexes = [
             OnDiskIndex(

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -35,6 +35,11 @@ class TestRanking(unittest.TestCase):
             pd.unique(r._df.loc[r._df["q_id"].eq("q2"), "query"]).tolist(), ["query 2"]
         )
 
+        r_with_queries = Ranking.from_run(
+            RUN, queries={"q1": "query 1", "q2": "query 2"}
+        )
+        self.assertAlmostEqual(r, r_with_queries)
+
     def test_ff_scores(self):
         r1 = Ranking.from_run({"q1": {"d1": 1, "d2": 2}})
         r2 = Ranking.from_run({"q1": {"d1": 1, "d2": 2}})

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -3,6 +3,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import pandas as pd
+
 from fast_forward import Ranking
 
 RUN = {
@@ -20,13 +22,23 @@ class TestRanking(unittest.TestCase):
         self.assertIn("q2", r)
         self.assertNotIn("q3", r)
 
-    def test_sorting(self):
+    def test_sort(self):
         r = Ranking(RUN, sort=False)
         self.assertFalse(r.is_sorted)
         r.sort()
         self.assertTrue(r.is_sorted)
         self.assertEqual(r["q1"], {"d2": 300, "d1": 2, "d0": 1})
         self.assertEqual(r["q2"], {"d2": 600, "d3": 7, "d1": 5, "d0": 4})
+
+    def test_attach_queries(self):
+        r = Ranking(RUN)
+        r.attach_queries({"q1": "query 1", "q2": "query 2"})
+        self.assertEqual(
+            pd.unique(r._df.loc[r._df["q_id"].eq("q1"), "query"]).tolist(), ["query 1"]
+        )
+        self.assertEqual(
+            pd.unique(r._df.loc[r._df["q_id"].eq("q2"), "query"]).tolist(), ["query 2"]
+        )
 
     def test_eq(self):
         r1 = Ranking({"q1": {"d1": 1, "d2": 2}})

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -15,23 +15,15 @@ RUN = {
 
 class TestRanking(unittest.TestCase):
     def test_ranking(self):
-        r = Ranking(RUN)
+        r = Ranking.from_run(RUN)
         self.assertEqual({"q1", "q2"}, r.q_ids)
         self.assertEqual(len(r), 2)
         self.assertIn("q1", r)
         self.assertIn("q2", r)
         self.assertNotIn("q3", r)
 
-    def test_sort(self):
-        r = Ranking(RUN, sort=False)
-        self.assertFalse(r.is_sorted)
-        r.sort()
-        self.assertTrue(r.is_sorted)
-        self.assertEqual(r["q1"], {"d2": 300, "d1": 2, "d0": 1})
-        self.assertEqual(r["q2"], {"d2": 600, "d3": 7, "d1": 5, "d0": 4})
-
     def test_attach_queries(self):
-        r = Ranking(RUN)
+        r = Ranking.from_run(RUN)
         r.attach_queries({"q1": "query 1", "q2": "query 2"})
         self.assertEqual(
             pd.unique(r._df.loc[r._df["q_id"].eq("q1"), "query"]).tolist(), ["query 1"]
@@ -41,22 +33,24 @@ class TestRanking(unittest.TestCase):
         )
 
     def test_eq(self):
-        r1 = Ranking({"q1": {"d1": 1, "d2": 2}})
-        r2 = Ranking({"q1": {"d2": 2, "d1": 1}})
-        r3 = Ranking({"q1": {"d1": 2, "d2": 3}})
-        r4 = Ranking({"q1": {"d1": 1, "d2": 2}, "q2": {}})
+        r1 = Ranking.from_run({"q1": {"d1": 1, "d2": 2}})
+        r2 = Ranking.from_run({"q1": {"d2": 2, "d1": 1}})
+        r3 = Ranking.from_run({"q1": {"d1": 2, "d2": 3}})
+        r4 = Ranking.from_run({"q1": {"d1": 1, "d2": 2}, "q2": {}})
         self.assertEqual(r1, r2)
         self.assertNotEqual(r1, r3)
         self.assertEqual(r1, r4)
 
     def test_cut(self):
-        r = Ranking(RUN)
+        r = Ranking.from_run(RUN)
         r.cut(2)
-        r_expected = Ranking({"q1": {"d2": 300, "d1": 2}, "q2": {"d2": 600, "d3": 7}})
+        r_expected = Ranking.from_run(
+            {"q1": {"d2": 300, "d1": 2}, "q2": {"d2": 600, "d3": 7}}
+        )
         self.assertEqual(r, r_expected)
 
     def test_save_load(self):
-        r = Ranking(RUN, name="Dummy")
+        r = Ranking.from_run(RUN, name="Dummy")
         fd, f = tempfile.mkstemp()
         f = Path(f)
         r.save(f)

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -35,7 +35,7 @@ class TestRanking(unittest.TestCase):
         r4 = Ranking({"q1": {"d1": 1, "d2": 2}, "q2": {}})
         self.assertEqual(r1, r2)
         self.assertNotEqual(r1, r3)
-        self.assertNotEqual(r1, r4)
+        self.assertEqual(r1, r4)
 
     def test_cut(self):
         r = Ranking(RUN)

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from fast_forward import Ranking
@@ -40,7 +41,7 @@ class TestRanking(unittest.TestCase):
 
         self.assertFalse(r1.has_ff_scores)
         self.assertEqual(r1, r2)
-        r1._df["ff_score"] = range(len(r1._df))
+        r1._df["ff_score"] = list(map(np.float32, range(len(r1._df))))
         self.assertTrue(r1.has_ff_scores)
         self.assertNotEqual(r1, r2)
 
@@ -74,6 +75,18 @@ class TestRanking(unittest.TestCase):
         self.assertEqual(r.name, r_from_file.name)
         os.close(fd)
         os.remove(f)
+
+    def test_interpolate(self):
+        r = Ranking.from_run(RUN)
+        r._df["ff_score"] = list(map(np.float32, range(len(r._df))))
+        r_int = r.interpolate(0.5, inplace=False)
+        self.assertNotEqual(r, r_int)
+        self.assertEqual(r_int["q1"], {"d2": 152.0, "d1": 3.5, "d0": 3.5})
+        self.assertEqual(r_int["q2"], {"d2": 300.0, "d3": 4.0, "d1": 3.5, "d0": 3.5})
+        r.interpolate(0.5, inplace=True)
+        print(r._df.dtypes)
+        print(r_int._df.dtypes)
+        self.assertEqual(r, r_int)
 
 
 if __name__ == "__main__":

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -24,7 +24,9 @@ class TestRanking(unittest.TestCase):
 
     def test_attach_queries(self):
         r = Ranking.from_run(RUN)
+        self.assertFalse(r.has_queries)
         r.attach_queries({"q1": "query 1", "q2": "query 2"})
+        self.assertTrue(r.has_queries)
         self.assertEqual(
             pd.unique(r._df.loc[r._df["q_id"].eq("q1"), "query"]).tolist(), ["query 1"]
         )

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -63,12 +63,10 @@ class TestRanking(unittest.TestCase):
         self.assertNotEqual(r1, 0)
 
     def test_cut(self):
-        r = Ranking.from_run(RUN)
-        r.cut(2)
-        r_expected = Ranking.from_run(
-            {"q1": {"d2": 300, "d1": 2}, "q2": {"d2": 600, "d3": 7}}
+        self.assertEqual(
+            Ranking.from_run(RUN).cut(2),
+            Ranking.from_run({"q1": {"d2": 300, "d1": 2}, "q2": {"d2": 600, "d3": 7}}),
         )
-        self.assertEqual(r, r_expected)
 
     def test_save_load(self):
         r = Ranking.from_run(RUN, name="Dummy")
@@ -84,14 +82,10 @@ class TestRanking(unittest.TestCase):
     def test_interpolate(self):
         r = Ranking.from_run(RUN)
         r._df["ff_score"] = list(map(np.float32, range(len(r._df))))
-        r_int = r.interpolate(0.5, inplace=False)
+        r_int = r.interpolate(0.5)
         self.assertNotEqual(r, r_int)
         self.assertEqual(r_int["q1"], {"d2": 152.0, "d1": 3.5, "d0": 3.5})
         self.assertEqual(r_int["q2"], {"d2": 300.0, "d3": 4.0, "d1": 3.5, "d0": 3.5})
-        r.interpolate(0.5, inplace=True)
-        print(r._df.dtypes)
-        print(r_int._df.dtypes)
-        self.assertEqual(r, r_int)
 
 
 if __name__ == "__main__":

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -34,6 +34,16 @@ class TestRanking(unittest.TestCase):
             pd.unique(r._df.loc[r._df["q_id"].eq("q2"), "query"]).tolist(), ["query 2"]
         )
 
+    def test_ff_scores(self):
+        r1 = Ranking.from_run({"q1": {"d1": 1, "d2": 2}})
+        r2 = Ranking.from_run({"q1": {"d1": 1, "d2": 2}})
+
+        self.assertFalse(r1.has_ff_scores)
+        self.assertEqual(r1, r2)
+        r1._df["ff_score"] = range(len(r1._df))
+        self.assertTrue(r1.has_ff_scores)
+        self.assertNotEqual(r1, r2)
+
     def test_eq(self):
         r1 = Ranking.from_run({"q1": {"d1": 1, "d2": 2}})
         r2 = Ranking.from_run({"q1": {"d2": 2, "d1": 1}})
@@ -42,6 +52,9 @@ class TestRanking(unittest.TestCase):
         self.assertEqual(r1, r2)
         self.assertNotEqual(r1, r3)
         self.assertEqual(r1, r4)
+
+        self.assertNotEqual(r1, "string")
+        self.assertNotEqual(r1, 0)
 
     def test_cut(self):
         r = Ranking.from_run(RUN)

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -87,13 +87,20 @@ class TestRanking(unittest.TestCase):
         self.assertEqual(r_int["q2"], {"d2": 300.0, "d3": 4.0, "d1": 3.5, "d0": 3.5})
 
     def test_early_stopping(self):
-        r = Ranking.from_run(RUN, queries=DUMMY_QUERIES)
+        r = Ranking.from_run(RUN)
+        r_with_queries = Ranking.from_run(RUN, queries=DUMMY_QUERIES)
         r._df["ff_score"] = [4.0, 5.0, 3.0, 2.0, 4.0, 3.0, 2.0]
         r._df["ff_score"] = r._df["ff_score"].astype(np.float32)
+        r_with_queries._df["ff_score"] = [4.0, 5.0, 3.0, 2.0, 4.0, 3.0, 2.0]
+        r_with_queries._df["ff_score"] = r._df["ff_score"].astype(np.float32)
         for cutoff in (1, 2, 3):
             self.assertEqual(
-                r.interpolate(0.5).cut(cutoff),
-                r.interpolate_early_stopping(0.5, cutoff),
+                r.interpolate(0.5, early_stopping=False).cut(cutoff),
+                r.interpolate(0.5, cutoff, early_stopping=True),
+            )
+            self.assertEqual(
+                r_with_queries.interpolate(0.5, early_stopping=False).cut(cutoff),
+                r_with_queries.interpolate(0.5, cutoff, early_stopping=True),
             )
 
 


### PR DESCRIPTION
- Rankings are now represented using pandas data frames.
- Queries can now be attached to a ranking.
- FF indexes now need to be called directly (`Index.__call__`). The `Index.get_scores` method is removed.
- FF scores are attached to the ranking.
- Interpolation is now done using `Ranking.interpolate`.