### PR TITLE
Indexing

### DIFF
--- a/fast_forward/__init__.py
+++ b/fast_forward/__init__.py
@@ -7,4 +7,5 @@ __version__ = "0.1.0"
 from fast_forward.index import Mode
 from fast_forward.index.disk import OnDiskIndex
 from fast_forward.index.memory import InMemoryIndex
+from fast_forward.indexer import Indexer
 from fast_forward.ranking import Ranking

--- a/fast_forward/encoder.py
+++ b/fast_forward/encoder.py
@@ -10,7 +10,7 @@ class Encoder(abc.ABC):
     """Base class for encoders."""
 
     @abc.abstractmethod
-    def encode(self, texts: Sequence[str]) -> np.ndarray:
+    def __call__(self, texts: Sequence[str]) -> np.ndarray:
         """Encode a list of texts.
 
         Args:
@@ -43,7 +43,7 @@ class TransformerEncoder(Encoder):
         self.device = device
         self.tokenizer_args = tokenizer_args
 
-    def encode(self, texts: Sequence[str]) -> np.ndarray:
+    def __call__(self, texts: Sequence[str]) -> np.ndarray:
         inputs = self.tokenizer(texts, return_tensors="pt", **self.tokenizer_args)
         inputs.to(self.device)
         embeddings = self.model(**inputs).pooler_output.detach().cpu().numpy()
@@ -62,7 +62,7 @@ class LambdaEncoder(Encoder):
         super().__init__()
         self._f = f
 
-    def encode(self, texts: Sequence[str]) -> np.ndarray:
+    def __call__(self, texts: Sequence[str]) -> np.ndarray:
         return np.array(list(map(self._f, texts)))
 
 
@@ -73,7 +73,7 @@ class TCTColBERTQueryEncoder(TransformerEncoder):
     https://github.com/castorini/pyserini/blob/310c828211bb3b9528cfd59695184c80825684a2/pyserini/encode/_tct_colbert.py#L72
     """
 
-    def encode(self, queries: Sequence[str]) -> np.ndarray:
+    def __call__(self, queries: Sequence[str]) -> np.ndarray:
         max_length = 36
         inputs = self.tokenizer(
             ["[CLS] [Q] " + q + "[MASK]" * max_length for q in queries],

--- a/fast_forward/encoder.py
+++ b/fast_forward/encoder.py
@@ -1,5 +1,4 @@
 import abc
-import logging
 from pathlib import Path
 from typing import Callable, Sequence, Union
 
@@ -7,27 +6,24 @@ import numpy as np
 from transformers import AutoModel, AutoTokenizer
 
 
-LOGGER = logging.getLogger(__name__)
-
-
-class QueryEncoder(abc.ABC):
-    """Base class for query encoders."""
+class Encoder(abc.ABC):
+    """Base class for encoders."""
 
     @abc.abstractmethod
-    def encode(self, queries: Sequence[str]) -> np.ndarray:
-        """Encode a list of queries.
+    def encode(self, texts: Sequence[str]) -> np.ndarray:
+        """Encode a list of texts.
 
         Args:
-            queries (Sequence[str]): The queries to encode.
+            texts (Sequence[str]): The texts to encode.
 
         Returns:
-            np.ndarray: The query representations.
+            np.ndarray: The resulting vector representations.
         """
         pass
 
 
-class TransformerQueryEncoder(QueryEncoder):
-    """Query encoder for transformer models. Returns the pooler output."""
+class TransformerEncoder(Encoder):
+    """Uses a pre-trained transformer model for encoding. Returns the pooler output."""
 
     def __init__(
         self, model: Union[str, Path], device: str = "cpu", **tokenizer_args
@@ -36,38 +32,51 @@ class TransformerQueryEncoder(QueryEncoder):
 
         Args:
             model (Union[str, Path]): Pre-trained transformer model (name or path).
-            device (str, optional): PyTorch device. Defaults to 'cpu'.
+            device (str, optional): PyTorch device. Defaults to "cpu".
             **tokenizer_args: Additional tokenizer arguments.
         """
-        if "tct_colbert" in model and not isinstance(self, TCTColBERTQueryEncoder):
-            LOGGER.warn("consider using the TCTColBERTQueryEncoder class")
-
         super().__init__()
         self.model = AutoModel.from_pretrained(model)
         self.model.to(device)
+        self.model.eval()
         self.tokenizer = AutoTokenizer.from_pretrained(model)
         self.device = device
         self.tokenizer_args = tokenizer_args
 
-    def encode(self, queries: Sequence[str]) -> np.ndarray:
-        inputs = self.tokenizer(queries, return_tensors="pt", **self.tokenizer_args)
+    def encode(self, texts: Sequence[str]) -> np.ndarray:
+        inputs = self.tokenizer(texts, return_tensors="pt", **self.tokenizer_args)
         inputs.to(self.device)
         embeddings = self.model(**inputs).pooler_output.detach().cpu().numpy()
         return embeddings
 
 
-class TCTColBERTQueryEncoder(TransformerQueryEncoder):
+class LambdaEncoder(Encoder):
+    """Encoder adapter class for arbitrary encoding functions."""
+
+    def __init__(self, f: Callable[[str], np.ndarray]) -> None:
+        """Constructor.
+
+        Args:
+            f (Callable[[str], np.ndarray]): Function to encode a single piece of text.
+        """
+        super().__init__()
+        self._f = f
+
+    def encode(self, texts: Sequence[str]) -> np.ndarray:
+        return np.array(list(map(self._f, texts)))
+
+
+class TCTColBERTQueryEncoder(TransformerEncoder):
     """Query encoder for pre-trained TCT-ColBERT models.
 
     Adapted from Pyserini:
-    https://github.com/castorini/pyserini/blob/70d79b420316d20302faaa000e08daa2416ed6e9/pyserini/dsearch/_dsearcher.py#L102
+    https://github.com/castorini/pyserini/blob/310c828211bb3b9528cfd59695184c80825684a2/pyserini/encode/_tct_colbert.py#L72
     """
 
     def encode(self, queries: Sequence[str]) -> np.ndarray:
         max_length = 36
-        queries = ["[CLS] [Q] " + q + "[MASK]" * max_length for q in queries]
         inputs = self.tokenizer(
-            queries,
+            ["[CLS] [Q] " + q + "[MASK]" * max_length for q in queries],
             max_length=max_length,
             truncation=True,
             add_special_tokens=False,
@@ -78,19 +87,3 @@ class TCTColBERTQueryEncoder(TransformerQueryEncoder):
         outputs = self.model(**inputs)
         embeddings = outputs.last_hidden_state.detach().cpu().numpy()
         return np.average(embeddings[:, 4:, :], axis=-2)
-
-
-class LambdaQueryEncoder(QueryEncoder):
-    """Query encoder adapter class for arbitrary encoding functions."""
-
-    def __init__(self, func: Callable[[str], np.ndarray]) -> None:
-        """Constructor.
-
-        Args:
-            func (Callable[[str], np.ndarray]): Function to encode a single query.
-        """
-        super().__init__()
-        self._func = func
-
-    def encode(self, queries: Sequence[str]) -> np.ndarray:
-        return np.array(list(map(self._func, queries)))

--- a/fast_forward/encoder.py
+++ b/fast_forward/encoder.py
@@ -106,7 +106,7 @@ class TCTColBERTDocumentEncoder(TransformerEncoder):
         sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
         return sum_embeddings / sum_mask
 
-    def encode(self, texts: Sequence[str]) -> np.ndarray:
+    def __call__(self, texts: Sequence[str]) -> np.ndarray:
         max_length = 512
         inputs = self.tokenizer(
             ["[CLS] [D] " + text for text in texts],

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -60,7 +60,7 @@ class Index(abc.ABC):
         result = []
         for i in range(0, len(queries), self._encoder_batch_size):
             batch = queries[i : i + self._encoder_batch_size]
-            result.append(self._query_encoder.encode(batch))
+            result.append(self._query_encoder(batch))
         return np.concatenate(result)
 
     @property

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -6,7 +6,7 @@ from typing import Iterable, List, Sequence, Set, Tuple, Union
 
 import numpy as np
 
-from fast_forward.encoder import QueryEncoder
+from fast_forward.encoder import Encoder
 from fast_forward.ranking import Ranking
 
 LOGGER = logging.getLogger(__name__)
@@ -26,14 +26,14 @@ class Index(abc.ABC):
 
     def __init__(
         self,
-        query_encoder: QueryEncoder = None,
+        query_encoder: Encoder = None,
         mode: Mode = Mode.PASSAGE,
         encoder_batch_size: int = 32,
     ) -> None:
         """Constructor.
 
         Args:
-            query_encoder (QueryEncoder, optional): The query encoder to use. Defaults to None.
+            query_encoder (Encoder, optional): The query encoder to use. Defaults to None.
             mode (Mode, optional): Retrieval mode. Defaults to Mode.PASSAGE.
             encoder_batch_size (int, optional): Encoder batch size. Defaults to 32.
         """
@@ -64,22 +64,22 @@ class Index(abc.ABC):
         return np.concatenate(result)
 
     @property
-    def query_encoder(self) -> QueryEncoder:
+    def query_encoder(self) -> Encoder:
         """Return the query encoder.
 
         Returns:
-            QueryEncoder: The encoder.
+            Encoder: The encoder.
         """
         return self._query_encoder
 
     @query_encoder.setter
-    def query_encoder(self, encoder: QueryEncoder) -> None:
+    def query_encoder(self, encoder: Encoder) -> None:
         """Set the query encoder.
 
         Args:
-            encoder (QueryEncoder): The encoder.
+            encoder (Encoder): The encoder.
         """
-        assert encoder is None or isinstance(encoder, QueryEncoder)
+        assert encoder is None or isinstance(encoder, Encoder)
         self._query_encoder = encoder
 
     @property

--- a/fast_forward/index/disk.py
+++ b/fast_forward/index/disk.py
@@ -8,7 +8,7 @@ import numpy as np
 from tqdm import tqdm
 
 import fast_forward
-from fast_forward.encoder import QueryEncoder
+from fast_forward.encoder import Encoder
 from fast_forward.index import Index, Mode
 from fast_forward.index.memory import InMemoryIndex
 
@@ -26,7 +26,7 @@ class OnDiskIndex(Index):
         self,
         index_file: Path,
         dim: int,
-        query_encoder: QueryEncoder = None,
+        query_encoder: Encoder = None,
         mode: Mode = Mode.PASSAGE,
         encoder_batch_size: int = 32,
         init_size: int = 2**14,
@@ -42,7 +42,7 @@ class OnDiskIndex(Index):
         Args:
             index_file (Path): Index file to create (or overwrite).
             dim (int): Vector dimension.
-            query_encoder (QueryEncoder, optional): Query encoder. Defaults to None.
+            query_encoder (Encoder, optional): Query encoder. Defaults to None.
             mode (Mode, optional): Ranking mode. Defaults to Mode.PASSAGE.
             encoder_batch_size (int, optional): Batch size for query encoder. Defaults to 32.
             init_size (int, optional): Initial size to allocate (number of vectors). Defaults to 2**14.
@@ -257,7 +257,7 @@ class OnDiskIndex(Index):
     def load(
         cls,
         index_file: Path,
-        encoder: QueryEncoder = None,
+        encoder: Encoder = None,
         mode: Mode = Mode.PASSAGE,
         encoder_batch_size: int = 32,
         resize_min_val: int = 2**10,
@@ -267,7 +267,7 @@ class OnDiskIndex(Index):
 
         Args:
             index_file (Path): Index file to open.
-            encoder (QueryEncoder, optional): Query encoder. Defaults to None.
+            encoder (Encoder, optional): Query encoder. Defaults to None.
             mode (Mode, optional): Ranking mode. Defaults to Mode.PASSAGE.
             encoder_batch_size (int, optional): Batch size for query encoder. Defaults to 32.
             resize_min_val (int, optional): Minimum number of vectors to increase index size by. Defaults to 2**10.

--- a/fast_forward/index/memory.py
+++ b/fast_forward/index/memory.py
@@ -4,7 +4,7 @@ from typing import Iterable, List, Sequence, Set, Tuple, Union
 
 import numpy as np
 
-from fast_forward.encoder import QueryEncoder
+from fast_forward.encoder import Encoder
 from fast_forward.index import Index, Mode
 
 LOGGER = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ class InMemoryIndex(Index):
     def __init__(
         self,
         dim: int,
-        query_encoder: QueryEncoder = None,
+        query_encoder: Encoder = None,
         mode: Mode = Mode.PASSAGE,
         encoder_batch_size: int = 32,
         init_size: int = 2**14,
@@ -27,7 +27,7 @@ class InMemoryIndex(Index):
 
         Args:
             dim (int): Vector dimension.
-            query_encoder (QueryEncoder, optional): The query encoder to use. Defaults to None.
+            query_encoder (Encoder, optional): The query encoder to use. Defaults to None.
             mode (Mode, optional): Indexing mode. Defaults to Mode.PASSAGE.
             encoder_batch_size (int, optional): Query encoder batch size. Defaults to 32.
             init_size (int, optional): Initial index size. Defaults to 2**14.

--- a/fast_forward/indexer.py
+++ b/fast_forward/indexer.py
@@ -1,0 +1,44 @@
+from typing import Dict, Iterable
+
+from tqdm import tqdm
+
+from fast_forward.encoder import Encoder
+from fast_forward.index import Index
+
+
+class Indexer(object):
+    """Utility class for indexing collections."""
+
+    def __init__(self, index: Index, encoder: Encoder, batch_size: int = 32) -> None:
+        """Constructor.
+
+        Args:
+            index (Index): The index to add the collection to.
+            encoder (Encoder): Document/passage encoder.
+            batch_size (int, optional): Btach size for encoding. Defaults to 32.
+        """
+        self._index = index
+        self._encoder = encoder
+        self._batch_size = batch_size
+
+    def index_dicts(self, data: Iterable[Dict[str, str]]) -> None:
+        """Index data from dictionaries.
+        The dictionaries should have the keys "text", "doc_id", "psg_id".
+
+        Args:
+            data (Iterable[Dict[str, str]]): An iterable of the dictionaries.
+        """
+        texts, doc_ids, psg_ids = [], [], []
+        for d in tqdm(data):
+            texts.append(d["text"])
+            if "doc_id" in d:
+                doc_ids.append(d["doc_id"])
+            if "psg_id" in d:
+                psg_ids.append(d["psg_id"])
+
+            if len(texts) == self._batch_size:
+                self._index.add(self._encoder(texts), doc_ids=doc_ids, psg_ids=psg_ids)
+                texts, doc_ids, psg_ids = [], [], []
+
+        if len(texts) > 0:
+            self._index.add(self._encoder(texts), doc_ids=doc_ids, psg_ids=psg_ids)

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -13,7 +13,7 @@ class TestTCTColBERTQueryEncoder(unittest.TestCase):
         )
 
     def test_encode(self):
-        q_enc = self.encoder.encode(["test query 1", "test query 2"])
+        q_enc = self.encoder(["test query 1", "test query 2"])
         self.assertEqual(q_enc.shape, (2, 768))
 
 
@@ -23,7 +23,7 @@ class TestLambdaEncoder(unittest.TestCase):
         self.encoder = LambdaEncoder(lambda q: np.zeros(shape=(768,)))
 
     def test_encode(self):
-        q_enc = self.encoder.encode(["test query 1", "test query 2"])
+        q_enc = self.encoder(["test query 1", "test query 2"])
         self.assertTrue(np.array_equal(q_enc, np.zeros(shape=(2, 768))))
 
 

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -2,19 +2,30 @@ import unittest
 
 import numpy as np
 
-from fast_forward.encoder import LambdaEncoder, TCTColBERTQueryEncoder
+from fast_forward.encoder import (
+    LambdaEncoder,
+    TCTColBERTDocumentEncoder,
+    TCTColBERTQueryEncoder,
+)
 
 
-class TestTCTColBERTQueryEncoder(unittest.TestCase):
+class TestTCTColBERTEncoder(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.encoder = TCTColBERTQueryEncoder(
+        self.query_encoder = TCTColBERTQueryEncoder(
+            "castorini/tct_colbert-msmarco", device="cpu"
+        )
+        self.doc_encoder = TCTColBERTDocumentEncoder(
             "castorini/tct_colbert-msmarco", device="cpu"
         )
 
-    def test_encode(self):
-        q_enc = self.encoder(["test query 1", "test query 2"])
-        self.assertEqual(q_enc.shape, (2, 768))
+    def test_query_encoder(self):
+        out = self.query_encoder(["test query 1", "test query 2"])
+        self.assertEqual(out.shape, (2, 768))
+
+    def test_query_encoder(self):
+        out = self.doc_encoder(["test doc 1", "test doc 2"])
+        self.assertEqual(out.shape, (2, 768))
 
 
 class TestLambdaEncoder(unittest.TestCase):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from fast_forward.encoder import TCTColBERTQueryEncoder, LambdaQueryEncoder
+from fast_forward.encoder import LambdaEncoder, TCTColBERTQueryEncoder
 
 
 class TestTCTColBERTQueryEncoder(unittest.TestCase):
@@ -17,10 +17,10 @@ class TestTCTColBERTQueryEncoder(unittest.TestCase):
         self.assertEqual(q_enc.shape, (2, 768))
 
 
-class TestLambdaQueryEncoder(unittest.TestCase):
+class TestLambdaEncoder(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.encoder = LambdaQueryEncoder(lambda q: np.zeros(shape=(768,)))
+        self.encoder = LambdaEncoder(lambda q: np.zeros(shape=(768,)))
 
     def test_encode(self):
         q_enc = self.encoder.encode(["test query 1", "test query 2"])

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -23,7 +23,7 @@ class TestTCTColBERTEncoder(unittest.TestCase):
         out = self.query_encoder(["test query 1", "test query 2"])
         self.assertEqual(out.shape, (2, 768))
 
-    def test_query_encoder(self):
+    def test_doc_encoder(self):
         out = self.doc_encoder(["test doc 1", "test doc 2"])
         self.assertEqual(out.shape, (2, 768))
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 
 from fast_forward import InMemoryIndex, Mode, OnDiskIndex, Ranking
-from fast_forward.encoder import LambdaQueryEncoder
+from fast_forward.encoder import LambdaEncoder
 from fast_forward.util import create_coalesced_index
 
 DUMMY_QUERIES = {"q1": "query 1", "q2": "query 2"}
@@ -33,7 +33,7 @@ DUMMY_PSG_RUN = {
     "q2": {"p0": 500, "p1": 6, "p2": 7, "p3": 8, "p4": 9},
 }
 DUMMY_PSG_RANKING = Ranking.from_run(DUMMY_PSG_RUN, queries=DUMMY_QUERIES)
-DUMMY_ENCODER = LambdaQueryEncoder(lambda _: np.array([1, 1, 1, 1, 1]))
+DUMMY_ENCODER = LambdaEncoder(lambda _: np.array([1, 1, 1, 1, 1]))
 
 
 class TestIndex(unittest.TestCase):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,37 @@
+import unittest
+
+import numpy as np
+
+from fast_forward.encoder import LambdaEncoder
+from fast_forward.index.memory import InMemoryIndex
+from fast_forward.indexer import Indexer
+
+
+class TestIndexer(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.index = InMemoryIndex(16)
+        self.indexer = Indexer(
+            self.index, LambdaEncoder(lambda q: np.zeros(shape=(16,))), batch_size=2
+        )
+
+    def test_index_dicts(self):
+        self.indexer.index_dicts(
+            [
+                {"text": "doc 1", "doc_id": "d1", "psg_id": "d1_p1"},
+                {"text": "doc 1", "doc_id": "d1", "psg_id": "d1_p2"},
+                {"text": "doc 1", "doc_id": "d1", "psg_id": "d1_p3"},
+                {"text": "doc 2", "doc_id": "d2", "psg_id": "d2_p1"},
+                {"text": "doc 3", "doc_id": "d3", "psg_id": "d3_p1"},
+            ]
+        )
+        self.assertEqual(5, len(self.index))
+        self.assertEqual(set(("d1", "d2", "d3")), self.index._get_doc_ids())
+        self.assertEqual(
+            set(("d1_p1", "d1_p2", "d1_p3", "d2_p1", "d3_p1")),
+            self.index._get_psg_ids(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add a utility class for indexing (`Indexer`)
- Rename `QueryEncoder` base class to `Encoder`
- add TCT ColBERT document encoder
- Encoders are now called directly (`__call__`) instead of using the `encode` method