### PR TITLE
Index operations

### DIFF
--- a/fast_forward/index/memory.py
+++ b/fast_forward/index/memory.py
@@ -72,21 +72,16 @@ class InMemoryIndex(Index):
             )
 
         # assign passage and document IDs
-        j = len(self)
-        for doc_id in doc_ids:
-            if doc_id is None:
-                continue
-            self._doc_id_to_idx[doc_id].append(j)
-            j += 1
+        for i, doc_id in enumerate(doc_ids, len(self)):
+            if doc_id is not None:
+                self._doc_id_to_idx[doc_id].append(i)
 
-        j = len(self)
-        for psg_id in psg_ids:
+        for i, psg_id in enumerate(psg_ids, len(self)):
             if psg_id is None:
                 continue
             if psg_id in self._psg_id_to_idx:
                 raise RuntimeError(f"Passage ID {psg_id} already exists.")
-            self._psg_id_to_idx[psg_id] = j
-            j += 1
+            self._psg_id_to_idx[psg_id] = i
 
         # add vectors to shards
         added = 0

--- a/fast_forward/index/memory.py
+++ b/fast_forward/index/memory.py
@@ -28,7 +28,7 @@ class InMemoryIndex(Index):
         Args:
             dim (int): Vector dimension.
             query_encoder (Encoder, optional): The query encoder to use. Defaults to None.
-            mode (Mode, optional): Indexing mode. Defaults to Mode.PASSAGE.
+            mode (Mode, optional): Ranking mode. Defaults to Mode.PASSAGE.
             encoder_batch_size (int, optional): Query encoder batch size. Defaults to 32.
             init_size (int, optional): Initial index size. Defaults to 2**14.
             alloc_size (int, optional): Size of shard allocated when index is full. Defaults to 2**14.

--- a/fast_forward/indexer.py
+++ b/fast_forward/indexer.py
@@ -27,6 +27,7 @@ class Indexer(object):
 
     def index_dicts(self, data: Iterable[Dict[str, str]]) -> None:
         """Index data from dictionaries.
+
         The dictionaries should have the key "text" and at least one of "doc_id" and "psg_id".
 
         Args:
@@ -35,22 +36,12 @@ class Indexer(object):
         texts, doc_ids, psg_ids = [], [], []
         for d in tqdm(data):
             texts.append(d["text"])
-            if "doc_id" in d:
-                doc_ids.append(d["doc_id"])
-            if "psg_id" in d:
-                psg_ids.append(d["psg_id"])
+            doc_ids.append(d.get("doc_id"))
+            psg_ids.append(d.get("psg_id"))
 
             if len(texts) == self._batch_size:
-                self._index.add(
-                    self._encoder(texts),
-                    doc_ids=doc_ids if len(doc_ids) > 0 else None,
-                    psg_ids=psg_ids if len(psg_ids) > 0 else None,
-                )
+                self._index.add(self._encoder(texts), doc_ids=doc_ids, psg_ids=psg_ids)
                 texts, doc_ids, psg_ids = [], [], []
 
         if len(texts) > 0:
-            self._index.add(
-                self._encoder(texts),
-                doc_ids=doc_ids if len(doc_ids) > 0 else None,
-                psg_ids=psg_ids if len(psg_ids) > 0 else None,
-            )
+            self._index.add(self._encoder(texts), doc_ids=doc_ids, psg_ids=psg_ids)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -44,8 +44,20 @@ class TestIndex(unittest.TestCase):
         self.doc_psg_index.add(
             vectors=DUMMY_VECTORS, doc_ids=DUMMY_DOC_IDS, psg_ids=DUMMY_PSG_IDS
         )
-        self.index_partial_ids.add(vectors=DUMMY_VECTORS, doc_ids=DUMMY_DOC_IDS)
-        self.index_partial_ids.add(vectors=DUMMY_VECTORS, psg_ids=DUMMY_PSG_IDS)
+
+        # some vectors have only a document ID, some have only a passage ID, some have both
+        self.index_partial_ids.add(
+            vectors=DUMMY_VECTORS,
+            doc_ids=[None, None] + DUMMY_DOC_IDS[2:],
+            psg_ids=DUMMY_PSG_IDS[:-2] + [None, None],
+        )
+        # vectors have only document IDs
+        self.index_partial_ids.add(vectors=DUMMY_VECTORS[:2], doc_ids=DUMMY_DOC_IDS[:2])
+        # vectors have only passage IDs
+        self.index_partial_ids.add(
+            vectors=DUMMY_VECTORS[-2:], psg_ids=DUMMY_PSG_IDS[-2:]
+        )
+
         self.doc_index.add(vectors=DUMMY_VECTORS, doc_ids=DUMMY_DOC_IDS)
         self.psg_index.add(vectors=DUMMY_VECTORS, psg_ids=DUMMY_PSG_IDS)
 
@@ -57,7 +69,7 @@ class TestIndex(unittest.TestCase):
 
         self.assertEqual(set(DUMMY_DOC_IDS), self.index_partial_ids.doc_ids)
         self.assertEqual(set(DUMMY_PSG_IDS), self.index_partial_ids.psg_ids)
-        self.assertEqual(DUMMY_NUM * 2, len(self.index_partial_ids))
+        self.assertEqual(DUMMY_NUM + 4, len(self.index_partial_ids))
         self.assertEqual(DUMMY_DIM, self.index_partial_ids.dim)
 
         self.assertEqual(set(DUMMY_DOC_IDS), self.doc_index.doc_ids)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -183,18 +183,44 @@ class TestIndex(unittest.TestCase):
         )
 
     def test_errors(self):
+        # no IDs
         with self.assertRaises(ValueError):
             self.index_no_enc.add(DUMMY_VECTORS, doc_ids=None, psg_ids=None)
+
+        # too few IDs
+        with self.assertRaises(ValueError):
+            self.index_no_enc.add(
+                DUMMY_VECTORS, doc_ids=DUMMY_DOC_IDS[:-2], psg_ids=None
+            )
+        with self.assertRaises(ValueError):
+            self.index_no_enc.add(
+                DUMMY_VECTORS, doc_ids=None, psg_ids=DUMMY_PSG_IDS[:-2]
+            )
+
+        # missing ID
+        with self.assertRaises(ValueError):
+            self.index_no_enc.add(
+                DUMMY_VECTORS,
+                doc_ids=[None] + DUMMY_DOC_IDS[1:],
+                psg_ids=[None] + DUMMY_PSG_IDS[1:],
+            )
+
+        # encoding without encoder
         with self.assertRaises(RuntimeError):
             self.index_no_enc.encode_queries(["test"])
+
+        # adding vectors with wrong dimension
         with self.assertRaises(ValueError):
             self.index_wrong_dim.add(
                 DUMMY_VECTORS, doc_ids=DUMMY_DOC_IDS, psg_ids=DUMMY_PSG_IDS
             )
+
+        # ranking without queries
         ranking_no_queries = Ranking.from_run(DUMMY_DOC_RUN)
         with self.assertRaises(ValueError):
             self.doc_psg_index(ranking_no_queries)
 
+        # early stopping without required parameters
         with self.assertRaises(ValueError):
             self.doc_psg_index(
                 DUMMY_DOC_RANKING, early_stopping=10, early_stopping_alpha=None

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -105,7 +105,6 @@ class TestIndex(unittest.TestCase):
     def test_maxp(self):
         self.doc_psg_index.mode = Mode.MAXP
         result = self.doc_psg_index(DUMMY_DOC_RANKING)
-        print(result)
         self.assertEqual(
             result,
             Ranking.from_run(
@@ -143,8 +142,6 @@ class TestIndex(unittest.TestCase):
         )
 
         self.doc_psg_index.mode = Mode.AVEP
-        print(expected)
-        print(self.doc_psg_index(DUMMY_DOC_RANKING))
         self.assertEqual(
             self.doc_psg_index(DUMMY_DOC_RANKING),
             expected,
@@ -163,8 +160,6 @@ class TestIndex(unittest.TestCase):
             }
         )
         self.doc_psg_index.mode = Mode.PASSAGE
-        print(self.doc_psg_index(DUMMY_PSG_RANKING))
-        print(expected)
         self.assertEqual(
             self.doc_psg_index(DUMMY_PSG_RANKING),
             expected,
@@ -281,7 +276,6 @@ class TestIndex(unittest.TestCase):
             vectors_2, _ = self.coalesced_indexes[1]._get_vectors([doc_id])
             self.assertEqual(len(vectors_1), len(vectors_2))
             for v1, v2 in zip(vectors_1, vectors_2):
-                print(v1, v2)
                 self.assertTrue(np.array_equal(v1, v2))
 
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -23,10 +23,10 @@ class TestIndexer(unittest.TestCase):
                 {"text": "456", "doc_id": "d1", "psg_id": "d1_p3"},
                 {"text": "567", "doc_id": "d2", "psg_id": "d2_p1"},
                 {"text": "678", "doc_id": "d3", "psg_id": "d3_p1"},
+                {"text": "890", "doc_id": "d4"},
+                {"text": "901", "psg_id": "d5_p1"},
             ]
         )
-        self.indexer.index_dicts([{"text": "890", "doc_id": "d4"}])
-        self.indexer.index_dicts([{"text": "901", "psg_id": "d5_p1"}])
         self.assertEqual(7, len(self.index))
         self.assertEqual(set(("d1", "d2", "d3", "d4")), self.index._get_doc_ids())
         self.assertEqual(


### PR DESCRIPTION
- `Index.add`: Change type of IDs to be added from `Sequence[str]` to `Sequence[Optional[str]]` (allowing individual IDs to be `None`).
- Implement `Index.batch_iter` and `Index.__iter__` methods that allow for iteration over indexes.
- `Indexer.index_dicts`: handle cases correctly where some vectors have document IDs and some have passage IDs.