### PR TITLE
Vector quantization

### DIFF
--- a/fast_forward/docs/index.md
+++ b/fast_forward/docs/index.md
@@ -14,7 +14,7 @@ OnDiskIndexes can be loaded into memory using `fast_forward.index.disk.OnDiskInd
 The following snippet illustrates how to create a `fast_forward.index.disk.OnDiskIndex` object (given a `fast_forward.encoder.Encoder`, `my_query_encoder`) and add some vector representations to it:
 
 ```python
-my_index = OnDiskIndex(Path("my_index.h5"), 768, my_query_encoder)
+my_index = OnDiskIndex(Path("my_index.h5"), my_query_encoder)
 my_index.add(
     my_vectors,  # shape (3, 768)
     doc_ids=["d1", "d1", "d2"],

--- a/fast_forward/docs/main.md
+++ b/fast_forward/docs/main.md
@@ -72,6 +72,7 @@ first_stage_ranking.interpolate(out, 0.1).save(Path("/path/to/output/run.tsv"))
 
 - [create and use Fast-Forward indexes?](fast_forward/index.html)
 - [index a collection?](fast_forward/indexer.html)
+- [use quantization to reduce index size?](fast_forward/quantizer.html)
 - [create custom encoders?](fast_forward/encoder.html#custom-encoders)
 - [read, manipulate, and save rankings?](fast_forward/ranking.html)
 - [use Fast-Forward indexes with PyTerrier?](fast_forward/util.html#pyterrier-transformers)

--- a/fast_forward/docs/quantizer.md
+++ b/fast_forward/docs/quantizer.md
@@ -1,0 +1,22 @@
+Fast-Forward indexes support (product) quantization as a means of compressing an index. The `fast_forward.quantizer.Quantizer` class defines the interface for quantizers to implement. Currently, the following quantizers are available:
+
+- `fast_forward.quantizer.nanopq.NanoPQ`: Product quantization based on the [nanopq library](https://nanopq.readthedocs.io/en/stable/index.html).
+
+Quantizers must be trained **before** they are used with the corresponding Fast-Forward index. The typical workflow is as follows:
+
+```python
+from pathlib import Path
+
+import numpy as np
+
+from fast_forward import OnDiskIndex
+from fast_forward.quantizer.nanopq import NanoPQ
+
+# in practice, a subset of the encoded corpus should be used as training vectors
+training_vectors = np.random.normal(size=(2**10, 768)).astype(np.float32)
+
+quantizer = NanoPQ(M=8, Ks=256)
+quantizer.fit(training_vectors)
+
+index = OnDiskIndex(Path("index.h5"), quantizer=quantizer)
+```

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -52,6 +52,8 @@ class Index(abc.ABC):
         self.query_encoder = query_encoder
         self.mode = mode
         self._quantizer = quantizer
+        if quantizer is not None:
+            quantizer.set_attached()
         self._encoder_batch_size = encoder_batch_size
 
     def encode_queries(self, queries: Sequence[str]) -> np.ndarray:

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -116,7 +116,7 @@ class Index(abc.ABC):
         self._mode = mode
 
     @abc.abstractmethod
-    def _internal_dim(self) -> Optional[int]:
+    def _get_internal_dim(self) -> Optional[int]:
         """Return the dimensionality of the vectors in the index (internal method).
 
         If no vectors exist, return None. If a quantizer is used, return the dimension of the codes.
@@ -139,7 +139,7 @@ class Index(abc.ABC):
         """
         if self._quantizer is not None:
             return self._quantizer.dims[0]
-        return self._internal_dim()
+        return self._get_internal_dim()
 
     @property
     def doc_ids(self) -> Set[str]:

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -115,17 +115,31 @@ class Index(abc.ABC):
         assert isinstance(mode, Mode)
         self._mode = mode
 
-    @property
     @abc.abstractmethod
-    def dim(self) -> Optional[int]:
-        """Return the dimensionality of the vectors in the index or None if there are no vectors.
+    def _internal_dim(self) -> Optional[int]:
+        """Return the dimensionality of the vectors in the index (internal method).
 
-        If a quantizer is used, the dimension before qunatization is returned.
+        If no vectors exist, return None. If a quantizer is used, return the dimension of the codes.
 
         Returns:
             Optional[int]: The dimensionality (if any).
         """
         pass
+
+    @property
+    def dim(self) -> Optional[int]:
+        """Return the dimensionality of the vectors.
+
+        May return None if there are no vectors.
+
+        If a quantizer is used, the dimension before quantization is returned.
+
+        Returns:
+            Optional[int]: The dimensionality (if any).
+        """
+        if self._quantizer is not None:
+            return self._quantizer.dims[0]
+        return self._internal_dim()
 
     @property
     def doc_ids(self) -> Set[str]:

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -111,11 +111,11 @@ class Index(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def dim(self) -> int:
-        """Return the dimensionality of the vectors in the index.
+    def dim(self) -> Optional[int]:
+        """Return the dimensionality of the vectors in the index (or None if there are no vectors).
 
         Returns:
-            int: The dimensionality.
+            Optional[int]: The dimensionality (if any).
         """
         pass
 
@@ -219,7 +219,7 @@ class Index(abc.ABC):
         if not len(doc_ids) == len(psg_ids) == num_vectors:
             raise ValueError("Number of IDs does not match number of vectors.")
 
-        if dim != self.dim:
+        if self.dim is not None and dim != self.dim:
             raise ValueError(
                 f"Vector dimensionality ({dim}) does not match index dimensionality ({self.dim})."
             )

--- a/fast_forward/index/__init__.py
+++ b/fast_forward/index/__init__.py
@@ -117,7 +117,7 @@ class Index(abc.ABC):
 
     @abc.abstractmethod
     def _get_internal_dim(self) -> Optional[int]:
-        """Return the dimensionality of the vectors in the index (internal method).
+        """Return the dimensionality of the vectors (or codes) in the index (internal method).
 
         If no vectors exist, return None. If a quantizer is used, return the dimension of the codes.
 
@@ -128,7 +128,7 @@ class Index(abc.ABC):
 
     @property
     def dim(self) -> Optional[int]:
-        """Return the dimensionality of the vectors.
+        """Return the dimensionality of the vector index.
 
         May return None if there are no vectors.
 
@@ -225,7 +225,7 @@ class Index(abc.ABC):
         Raises:
             ValueError: When there are no document IDs and no passage IDs.
             ValueError: When the number of IDs does not match the number of vectors.
-            ValueError: When the vector and index dimensionalities don't match.
+            ValueError: When the input vector and index dimensionalities don't match.
             ValueError: When a vector has neither a document nor a passage ID.
             RuntimeError: When items can't be added to the index for any reason.
         """
@@ -243,7 +243,7 @@ class Index(abc.ABC):
 
         if self.dim is not None and dim != self.dim:
             raise ValueError(
-                f"Vector dimensionality ({dim}) does not match index dimensionality ({self.dim})."
+                f"Input vector dimensionality ({dim}) does not match index dimensionality ({self.dim})."
             )
 
         for doc_id, psg_id in zip(doc_ids, psg_ids):

--- a/fast_forward/index/disk.py
+++ b/fast_forward/index/disk.py
@@ -127,7 +127,7 @@ class OnDiskIndex(Index):
         with h5py.File(self._index_file, "r") as fp:
             return fp.attrs["num_vectors"]
 
-    def _internal_dim(self) -> Optional[int]:
+    def _get_internal_dim(self) -> Optional[int]:
         with h5py.File(self._index_file, "r") as fp:
             if "vectors" in fp:
                 return fp["vectors"].shape[1]

--- a/fast_forward/index/disk.py
+++ b/fast_forward/index/disk.py
@@ -127,14 +127,11 @@ class OnDiskIndex(Index):
         with h5py.File(self._index_file, "r") as fp:
             return fp.attrs["num_vectors"]
 
-    @property
-    def dim(self) -> Optional[int]:
-        if self._quantizer is not None:
-            return self._quantizer.dims[0]
+    def _internal_dim(self) -> Optional[int]:
         with h5py.File(self._index_file, "r") as fp:
             if "vectors" in fp:
                 return fp["vectors"].shape[1]
-            return None
+        return None
 
     def to_memory(self, buffer_size=None) -> InMemoryIndex:
         """Load the index entirely into memory.

--- a/fast_forward/index/disk.py
+++ b/fast_forward/index/disk.py
@@ -290,7 +290,7 @@ class OnDiskIndex(Index):
             )
             return vectors, [id_to_idxs[id] for id in ids]
 
-    def batch_iter(
+    def _batch_iter(
         self, batch_size: int
     ) -> Iterator[Tuple[np.ndarray, IDSequence, IDSequence]]:
         with h5py.File(self._index_file, "r") as fp:
@@ -331,6 +331,7 @@ class OnDiskIndex(Index):
             OnDiskIndex: The index.
         """
         LOGGER.debug("reading file %s", index_file)
+
         # deserialize quantizer if any
         with h5py.File(index_file, "r") as fp:
             if "quantizer" in fp:

--- a/fast_forward/index/memory.py
+++ b/fast_forward/index/memory.py
@@ -58,7 +58,7 @@ class InMemoryIndex(Index):
                 + self._idx_in_cur_shard
             )
 
-    def _internal_dim(self) -> Optional[int]:
+    def _get_internal_dim(self) -> Optional[int]:
         if len(self._shards) > 0:
             return self._shards[0].shape[-1]
         return None

--- a/fast_forward/index/memory.py
+++ b/fast_forward/index/memory.py
@@ -181,7 +181,7 @@ class InMemoryIndex(Index):
             return np.array([]), []
         return np.concatenate(result_vectors), [result_ids[id] for id in ids]
 
-    def batch_iter(
+    def _batch_iter(
         self, batch_size: int
     ) -> Iterator[Tuple[np.ndarray, IDSequence, IDSequence]]:
         LOGGER.info("creating ID mappings for this index")

--- a/fast_forward/index/memory.py
+++ b/fast_forward/index/memory.py
@@ -58,10 +58,7 @@ class InMemoryIndex(Index):
                 + self._idx_in_cur_shard
             )
 
-    @property
-    def dim(self) -> Optional[int]:
-        if self._quantizer is not None:
-            return self._quantizer.dims[0]
+    def _internal_dim(self) -> Optional[int]:
         if len(self._shards) > 0:
             return self._shards[0].shape[-1]
         return None

--- a/fast_forward/index/memory.py
+++ b/fast_forward/index/memory.py
@@ -16,31 +16,25 @@ class InMemoryIndex(Index):
 
     def __init__(
         self,
-        dim: int,
         query_encoder: Encoder = None,
         mode: Mode = Mode.PASSAGE,
         encoder_batch_size: int = 32,
         init_size: int = 2**14,
         alloc_size: int = 2**14,
-        dtype: np.dtype = np.float32,
     ) -> None:
         """Create an index.
 
         Args:
-            dim (int): Vector dimension.
             query_encoder (Encoder, optional): The query encoder to use. Defaults to None.
             mode (Mode, optional): Ranking mode. Defaults to Mode.PASSAGE.
             encoder_batch_size (int, optional): Query encoder batch size. Defaults to 32.
             init_size (int, optional): Initial index size. Defaults to 2**14.
             alloc_size (int, optional): Size of shard allocated when index is full. Defaults to 2**14.
-            dtype (np.dtype, optional): Vector dtype. Defaults to np.float32.
         """
         self._shards = []
         self._init_size = init_size
         self._alloc_size = alloc_size
-        self._dtype = dtype
         self._idx_in_cur_shard = 0
-        self._dim = dim
         self._doc_id_to_idx = defaultdict(list)
         self._psg_id_to_idx = {}
         super().__init__(query_encoder, mode, encoder_batch_size)
@@ -57,8 +51,10 @@ class InMemoryIndex(Index):
             )
 
     @property
-    def dim(self) -> int:
-        return self._dim
+    def dim(self) -> Optional[int]:
+        if len(self._shards) > 0:
+            return self._shards[0].shape[-1]
+        return None
 
     def _add(
         self,
@@ -69,7 +65,7 @@ class InMemoryIndex(Index):
         # if this is the first call to _add, no shards exist
         if len(self._shards) == 0:
             self._shards.append(
-                np.zeros((self._init_size, self._dim), dtype=self._dtype)
+                np.zeros((self._init_size, vectors.shape[-1]), dtype=vectors.dtype)
             )
 
         # assign passage and document IDs
@@ -88,12 +84,12 @@ class InMemoryIndex(Index):
         added = 0
         num_vectors = vectors.shape[0]
         while added < num_vectors:
-            cur_shard_size = self._shards[-1].shape[0]
+            cur_shard_size, dim = self._shards[-1].shape
 
             # if current shard is full, add a new one
             if self._idx_in_cur_shard == cur_shard_size:
                 LOGGER.debug("adding new shard")
-                self._shards.append(np.zeros((self._alloc_size, self._dim)))
+                self._shards.append(np.zeros((self._alloc_size, dim)))
                 self._idx_in_cur_shard = 0
                 cur_shard_size = self._alloc_size
 
@@ -172,7 +168,7 @@ class InMemoryIndex(Index):
             items_so_far += len(items)
 
         if len(result_vectors) == 0:
-            return np.array([], dtype=self._dtype), []
+            return np.array([]), []
         return np.concatenate(result_vectors), [result_ids[id] for id in ids]
 
     def batch_iter(

--- a/fast_forward/quantizer.py
+++ b/fast_forward/quantizer.py
@@ -1,0 +1,90 @@
+import abc
+import logging
+from typing import Dict, Optional, Union
+
+import numpy as np
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Quantizer(abc.ABC):
+    _attached: bool = False
+
+    @abc.abstractmethod
+    def _fit(self, vectors: np.ndarray) -> None:
+        """Fit the quantizer.
+
+        Args:
+            vectors (np.ndarray): The training vectors.
+        """
+        pass
+
+    def fit(self, vectors: np.ndarray) -> None:
+        """Fit (train) the quantizer.
+
+        Quantizers can only be trained before being attached to an index to avoid inconsistencies.
+
+        Args:
+            vectors (np.ndarray): The training vectors.
+
+        Raises:
+            RuntimeError: When the quantizer is aready attached to an index.
+        """
+        if self._attached:
+            raise RuntimeError(
+                "Quantizers can only be fitted before they are attached to an index."
+            )
+        self._fit(vectors)
+
+    @property
+    @abc.abstractmethod
+    def dtype(self) -> Optional[np.dtype]:
+        """The data type of the codes produced by this quantizer or None if the quantizer is not trained.
+
+        Returns:
+            Optional[np.dtype]: The data type (if any).
+        """
+        pass
+
+    @abc.abstractmethod
+    def encode(self, vectors: np.ndarray) -> np.ndarray:
+        """Encode a batch of vectors.
+
+        Args:
+            vectors (np.ndarray): The vectors to be encoded.
+
+        Returns:
+            np.ndarray: The codes corresponding to the vectors.
+        """
+        pass
+
+    @abc.abstractmethod
+    def decode(self, codes: np.ndarray) -> np.ndarray:
+        """Decode a batch of codes to obtain approximate vector representations.
+
+        Args:
+            codes (np.ndarray): The codes to be decoded.
+
+        Returns:
+            np.ndarray: The approximated vectors.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_state(self) -> Dict[str, Union[str, np.ndarray]]:
+        """Return a serialized representation of the quantizer that can be stored in the index.
+
+        Returns:
+            Dict[str, Union[str, np.ndarray]]: Key-value pairs representing the state of the quantizer.
+        """
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def load(state: Dict[str, Union[str, np.ndarray]]) -> "Quantizer":
+        """Load a (trained) quantizer based on its serialized representation.
+
+        Returns:
+            Quantizer: The loaded qunatizer.
+        """
+        pass

--- a/fast_forward/quantizer/__init__.py
+++ b/fast_forward/quantizer/__init__.py
@@ -163,7 +163,7 @@ class Quantizer(abc.ABC):
 
         Args:
             attributes (QuantizerAttributes): The quantizer attributes.
-            data (QuantizerData): The quantizer attributes.
+            data (QuantizerData): The quantizer data.
 
         Returns:
             Quantizer: The resulting quantizer.
@@ -173,18 +173,21 @@ class Quantizer(abc.ABC):
     @classmethod
     def deserialize(
         cls,
-        rep: Tuple[QuantizerAttributes, QuantizerAttributes, QuantizerData],
+        meta: QuantizerAttributes,
+        attributes: QuantizerAttributes,
+        data: QuantizerData,
     ) -> "Quantizer":
         """Reconstruct a serialized quantizer.
 
         Args:
-            rep (Tuple[QuantizerAttributes, QuantizerAttributes, QuantizerData]): The serialized quantizer.
+            meta (QuantizerAttributes): The quantizer metadata.
+            attributes (QuantizerAttributes): The quantizer attributes.
+            data (QuantizerData): The quantizer data.
 
         Returns:
             Quantizer: The loaded quantizer.
         """
-        meta, attributes, data = rep
-        LOGGER.debug("importing %s.%s", meta["__module__"], meta["__name__"])
+        LOGGER.debug("reconstructing %s.%s", meta["__module__"], meta["__name__"])
         quantizer_mod = importlib.import_module(meta["__module__"])
         quantizer_cls = getattr(quantizer_mod, meta["__name__"])
         quantizer = quantizer_cls._from_state(attributes, data)

--- a/fast_forward/quantizer/__init__.py
+++ b/fast_forward/quantizer/__init__.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, Union
+from typing import Any
 
 import numpy as np
 
@@ -106,22 +106,3 @@ class Quantizer(abc.ABC):
         if not self._trained:
             raise RuntimeError(f"Call {self.__class__.__name__}.fit first.")
         return self._decode(codes)
-
-    @abc.abstractmethod
-    def get_state(self) -> Dict[str, Union[bytes, np.ndarray]]:
-        """Return a serialized representation of the quantizer that can be stored in the index.
-
-        Returns:
-            Dict[str, Union[str, np.ndarray]]: Key-value pairs representing the state of the quantizer.
-        """
-        pass
-
-    @classmethod
-    @abc.abstractmethod
-    def load(cls, state: Dict[str, Union[bytes, np.ndarray]]) -> "Quantizer":
-        """Load a (trained) quantizer based on its serialized representation.
-
-        Returns:
-            Quantizer: The loaded qunatizer.
-        """
-        pass

--- a/fast_forward/quantizer/__init__.py
+++ b/fast_forward/quantizer/__init__.py
@@ -108,7 +108,7 @@ class Quantizer(abc.ABC):
         return self._decode(codes)
 
     @abc.abstractmethod
-    def get_state(self) -> Dict[str, Union[str, np.ndarray]]:
+    def get_state(self) -> Dict[str, Union[bytes, np.ndarray]]:
         """Return a serialized representation of the quantizer that can be stored in the index.
 
         Returns:
@@ -118,7 +118,7 @@ class Quantizer(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def load(cls, state: Dict[str, Union[str, np.ndarray]]) -> "Quantizer":
+    def load(cls, state: Dict[str, Union[bytes, np.ndarray]]) -> "Quantizer":
         """Load a (trained) quantizer based on its serialized representation.
 
         Returns:

--- a/fast_forward/quantizer/__init__.py
+++ b/fast_forward/quantizer/__init__.py
@@ -1,10 +1,7 @@
 import abc
-import logging
 from typing import Any, Dict, Union
 
 import numpy as np
-
-LOGGER = logging.getLogger(__name__)
 
 
 class Quantizer(abc.ABC):
@@ -121,7 +118,7 @@ class Quantizer(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def load(state: Dict[str, Union[str, np.ndarray]]) -> "Quantizer":
+    def load(cls, state: Dict[str, Union[str, np.ndarray]]) -> "Quantizer":
         """Load a (trained) quantizer based on its serialized representation.
 
         Returns:

--- a/fast_forward/quantizer/__init__.py
+++ b/fast_forward/quantizer/__init__.py
@@ -1,7 +1,7 @@
 import abc
 import importlib
 import logging
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 
@@ -67,11 +67,13 @@ class Quantizer(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def dim(self) -> int:
-        """The dimension of the codes produced by this quantizer.
+    def dims(self) -> Tuple[Optional[int], Optional[int]]:
+        """The dimensions before and after quantization.
+
+        May return None values before the quantizer is trained.
 
         Returns:
-            np.dtype: The dimension.
+            Tuple[Optional[int], Optional[int]]: Dimension of the original vectors and dimension of the codes.
         """
         pass
 

--- a/fast_forward/quantizer/__init__.py
+++ b/fast_forward/quantizer/__init__.py
@@ -1,3 +1,7 @@
+"""
+.. include:: ../docs/quantizer.md
+"""
+
 import abc
 import importlib
 import logging

--- a/fast_forward/quantizer/__init__.py
+++ b/fast_forward/quantizer/__init__.py
@@ -57,6 +57,16 @@ class Quantizer(abc.ABC):
         """
         pass
 
+    @property
+    @abc.abstractmethod
+    def dim(self) -> int:
+        """The dimension of the codes produced by this quantizer.
+
+        Returns:
+            np.dtype: The dimension.
+        """
+        pass
+
     @abc.abstractmethod
     def _encode(self, vectors: np.ndarray) -> np.ndarray:
         """Encode vectors (internal method).

--- a/fast_forward/quantizer/__init__.py
+++ b/fast_forward/quantizer/__init__.py
@@ -1,6 +1,6 @@
 import abc
 import logging
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
 
@@ -11,21 +11,23 @@ class Quantizer(abc.ABC):
     _attached: bool = False
 
     @abc.abstractmethod
-    def _fit(self, vectors: np.ndarray) -> None:
+    def _fit(self, vectors: np.ndarray, **kwargs: Any) -> None:
         """Fit the quantizer.
 
         Args:
             vectors (np.ndarray): The training vectors.
+            **kwargs (Any): Arguments specific to the quantizer.
         """
         pass
 
-    def fit(self, vectors: np.ndarray) -> None:
+    def fit(self, vectors: np.ndarray, **kwargs: Any) -> None:
         """Fit (train) the quantizer.
 
         Quantizers can only be trained before being attached to an index to avoid inconsistencies.
 
         Args:
             vectors (np.ndarray): The training vectors.
+            **kwargs (Any): Arguments specific to the quantizer.
 
         Raises:
             RuntimeError: When the quantizer is aready attached to an index.
@@ -34,7 +36,7 @@ class Quantizer(abc.ABC):
             raise RuntimeError(
                 "Quantizers can only be fitted before they are attached to an index."
             )
-        self._fit(vectors)
+        self._fit(vectors, **kwargs)
 
     @property
     @abc.abstractmethod

--- a/fast_forward/quantizer/__init__.py
+++ b/fast_forward/quantizer/__init__.py
@@ -17,7 +17,7 @@ class Quantizer(abc.ABC):
         """Set the quantizer as attached, preventing calls to `Quantizer.fit`."""
         if not self._trained:
             raise RuntimeError(
-                f"Call {self.__class__}.fit before attaching the quantizer to an index."
+                f"Call {self.__class__.__name__}.fit before attaching the quantizer to an index."
             )
         self._attached = True
 
@@ -82,7 +82,7 @@ class Quantizer(abc.ABC):
             np.ndarray: The codes corresponding to the vectors.
         """
         if not self._trained:
-            raise RuntimeError(f"Call {self.__class__}.fit first.")
+            raise RuntimeError(f"Call {self.__class__.__name__}.fit first.")
         return self._encode(vectors)
 
     @abc.abstractmethod
@@ -107,7 +107,7 @@ class Quantizer(abc.ABC):
             np.ndarray: The approximated vectors.
         """
         if not self._trained:
-            raise RuntimeError(f"Call {self.__class__}.fit first.")
+            raise RuntimeError(f"Call {self.__class__.__name__}.fit first.")
         return self._decode(codes)
 
     @abc.abstractmethod

--- a/fast_forward/quantizer/__init__.py
+++ b/fast_forward/quantizer/__init__.py
@@ -13,6 +13,14 @@ class Quantizer(abc.ABC):
     _attached: bool = False
     _trained: bool = False
 
+    def set_attached(self) -> None:
+        """Set the quantizer as attached, preventing calls to `Quantizer.fit`."""
+        if not self._trained:
+            raise RuntimeError(
+                f"Call {self.__class__}.fit before attaching the quantizer to an index."
+            )
+        self._attached = True
+
     @abc.abstractmethod
     def _fit(self, vectors: np.ndarray, **kwargs: Any) -> None:
         """Fit the quantizer (internal method).

--- a/fast_forward/quantizer/nanopq.py
+++ b/fast_forward/quantizer/nanopq.py
@@ -66,6 +66,8 @@ class NanoPQ(Quantizer):
             metric=attributes["metric"],
             verbose=attributes["verbose"],
         )
-        quantizer._pq.Ds = attributes["Ds"]
-        quantizer._pq.codewords = data["codewords"]
+        if "Ds" in attributes:
+            quantizer._pq.Ds = attributes["Ds"]
+        if "codewords" in data:
+            quantizer._pq.codewords = data["codewords"]
         return quantizer

--- a/fast_forward/quantizer/nanopq.py
+++ b/fast_forward/quantizer/nanopq.py
@@ -58,9 +58,7 @@ class NanoPQ(Quantizer):
     def _from_state(
         cls, attributes: QuantizerAttributes, data: QuantizerData
     ) -> "NanoPQ":
-        quantizer = cls.__new__(cls)
-        super(NanoPQ, quantizer).__init__()
-        quantizer._pq = nanopq.PQ(
+        quantizer = cls(
             M=attributes["M"],
             Ks=attributes["Ks"],
             metric=attributes["metric"],

--- a/fast_forward/quantizer/nanopq.py
+++ b/fast_forward/quantizer/nanopq.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 import nanopq
 import numpy as np
@@ -34,8 +34,10 @@ class NanoPQ(Quantizer):
         return self._pq.code_dtype
 
     @property
-    def dim(self) -> int:
-        return self._pq.M
+    def dims(self) -> Tuple[Optional[int], Optional[int]]:
+        if self._pq.Ds is None:
+            return None, self._pq.M
+        return self._pq.Ds * self._pq.M, self._pq.M
 
     def _encode(self, vectors: np.ndarray) -> np.ndarray:
         return self._pq.encode(vecs=vectors)

--- a/fast_forward/quantizer/nanopq.py
+++ b/fast_forward/quantizer/nanopq.py
@@ -1,0 +1,51 @@
+import pickle
+from typing import Any, Dict, Union
+
+import nanopq
+import numpy as np
+
+from fast_forward.quantizer import Quantizer
+
+
+class NanoPQQuantizer(Quantizer):
+    """Quantizer that uses the nanopq library.
+
+    More information is available [here](https://nanopq.readthedocs.io/en/stable/source/api.html#nanopq.PQ).
+    """
+
+    def __init__(
+        self, M: int, Ks: int, metric: str = "dot", verbose: bool = False
+    ) -> None:
+        """Instantiate a nanopq quantizer.
+
+        Args:
+            M (int): The number of subspaces.
+            Ks (int): The number of codewords per subspace.
+            metric (str, optional): The metric to use. Defaults to "dot".
+            verbose (bool, optional): Enable verbosity. Defaults to False.
+        """
+        self._pq = nanopq.PQ(M=M, Ks=Ks, metric=metric, verbose=verbose)
+        super().__init__()
+
+    def _fit(self, vectors: np.ndarray, **kwargs: Any) -> None:
+        self._pq.fit(vecs=vectors, **kwargs)
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._pq.code_dtype
+
+    def _encode(self, vectors: np.ndarray) -> np.ndarray:
+        return self._pq.encode(vecs=vectors)
+
+    def _decode(self, codes: np.ndarray) -> np.ndarray:
+        return self._pq.decode(codes=codes)
+
+    def get_state(self) -> Dict[str, Union[bytes, np.ndarray]]:
+        return {"obj_pkl": pickle.dumps(self._pq)}
+
+    @classmethod
+    def load(cls, state: Dict[str, Union[bytes, np.ndarray]]) -> "NanoPQQuantizer":
+        quantizer = cls.__new__(cls)
+        super(NanoPQQuantizer, quantizer).__init__()
+        quantizer._pq = pickle.loads(state["obj_pkl"])
+        return quantizer

--- a/fast_forward/quantizer/nanopq.py
+++ b/fast_forward/quantizer/nanopq.py
@@ -7,7 +7,7 @@ from fast_forward.quantizer import Quantizer, QuantizerAttributes, QuantizerData
 
 
 class NanoPQ(Quantizer):
-    """Product quantizer that uses the nanopq library.
+    """Product quantizer that uses the [nanopq library](https://nanopq.readthedocs.io/en/stable/index.html).
 
     More information is available [here](https://nanopq.readthedocs.io/en/stable/source/api.html#nanopq.PQ).
     """

--- a/fast_forward/quantizer/nanopq.py
+++ b/fast_forward/quantizer/nanopq.py
@@ -1,9 +1,9 @@
-from typing import Any
+from typing import Any, Tuple
 
 import nanopq
 import numpy as np
 
-from fast_forward.quantizer import Quantizer
+from fast_forward.quantizer import Quantizer, QuantizerAttributes, QuantizerData
 
 
 class NanoPQ(Quantizer):
@@ -42,3 +42,28 @@ class NanoPQ(Quantizer):
 
     def _decode(self, codes: np.ndarray) -> np.ndarray:
         return self._pq.decode(codes=codes)
+
+    def _get_state(self) -> Tuple[QuantizerAttributes, QuantizerData]:
+        attributes, data = {}, {}
+        for a in ("M", "Ks", "Ds", "metric", "verbose"):
+            if hasattr(self._pq, a):
+                attributes[a] = getattr(self._pq, a)
+        if hasattr(self._pq, "codewords"):
+            data["codewords"] = self._pq.codewords
+        return attributes, data
+
+    @classmethod
+    def _from_state(
+        cls, attributes: QuantizerAttributes, data: QuantizerData
+    ) -> "NanoPQ":
+        quantizer = cls.__new__(cls)
+        super(NanoPQ, quantizer).__init__()
+        quantizer._pq = nanopq.PQ(
+            M=attributes["M"],
+            Ks=attributes["Ks"],
+            metric=attributes["metric"],
+            verbose=attributes["verbose"],
+        )
+        quantizer._pq.Ds = attributes["Ds"]
+        quantizer._pq.codewords = data["codewords"]
+        return quantizer

--- a/fast_forward/quantizer/nanopq.py
+++ b/fast_forward/quantizer/nanopq.py
@@ -1,5 +1,4 @@
-import pickle
-from typing import Any, Dict, Union
+from typing import Any
 
 import nanopq
 import numpy as np
@@ -39,13 +38,3 @@ class NanoPQQuantizer(Quantizer):
 
     def _decode(self, codes: np.ndarray) -> np.ndarray:
         return self._pq.decode(codes=codes)
-
-    def get_state(self) -> Dict[str, Union[bytes, np.ndarray]]:
-        return {"obj_pkl": pickle.dumps(self._pq)}
-
-    @classmethod
-    def load(cls, state: Dict[str, Union[bytes, np.ndarray]]) -> "NanoPQQuantizer":
-        quantizer = cls.__new__(cls)
-        super(NanoPQQuantizer, quantizer).__init__()
-        quantizer._pq = pickle.loads(state["obj_pkl"])
-        return quantizer

--- a/fast_forward/quantizer/nanopq.py
+++ b/fast_forward/quantizer/nanopq.py
@@ -6,8 +6,8 @@ import numpy as np
 from fast_forward.quantizer import Quantizer
 
 
-class NanoPQQuantizer(Quantizer):
-    """Quantizer that uses the nanopq library.
+class NanoPQ(Quantizer):
+    """Product quantizer that uses the nanopq library.
 
     More information is available [here](https://nanopq.readthedocs.io/en/stable/source/api.html#nanopq.PQ).
     """

--- a/fast_forward/quantizer/nanopq.py
+++ b/fast_forward/quantizer/nanopq.py
@@ -33,6 +33,10 @@ class NanoPQQuantizer(Quantizer):
     def dtype(self) -> np.dtype:
         return self._pq.code_dtype
 
+    @property
+    def dim(self) -> int:
+        return self._pq.M
+
     def _encode(self, vectors: np.ndarray) -> np.ndarray:
         return self._pq.encode(vecs=vectors)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "transformers >= 4.28.0, < 5",
     "h5py >= 3.0.0, < 4",
     "tqdm >= 4.66.0, < 5",
+    "nanopq >= 0.2.1, < 0.3",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -342,7 +342,7 @@ class TestIndex(unittest.TestCase):
                 )
 
     def test_quantization(self):
-        self.assertEqual(2, self.quantized_index._internal_dim())
+        self.assertEqual(2, self.quantized_index._get_internal_dim())
 
         # make sure the dimensions of the returned vetors match the original dimension
         for vec, _, _ in self.quantized_index:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -233,12 +233,9 @@ class TestIndex(unittest.TestCase):
             )
 
     def test_early_stopping(self):
-        vectors = np.stack([[1, 0], [1, 1]] * 10)
-        psg_ids = [f"p{i}" for i in range(20)]
-        index = InMemoryIndex(
-            LambdaEncoder(lambda q: np.array([10, 10])), mode=Mode.PASSAGE
+        self.early_stopping_index.add(
+            np.stack([[1, 0], [1, 1]] * 10), psg_ids=[f"p{i}" for i in range(20)]
         )
-        index.add(vectors, psg_ids=psg_ids)
         r = Ranking(
             pd.DataFrame(
                 [
@@ -277,7 +274,7 @@ class TestIndex(unittest.TestCase):
         )
 
         self.assertEqual(
-            index(
+            self.early_stopping_index(
                 r,
                 early_stopping=5,
                 early_stopping_alpha=0.5,
@@ -288,7 +285,7 @@ class TestIndex(unittest.TestCase):
 
         # order of intervals should make no difference
         self.assertEqual(
-            index(
+            self.early_stopping_index(
                 r,
                 early_stopping=5,
                 early_stopping_alpha=0.5,
@@ -343,6 +340,9 @@ class TestInMemoryIndex(TestIndex):
         self.psg_index = InMemoryIndex(DUMMY_ENCODER)
         self.index_no_enc = InMemoryIndex(query_encoder=None)
         self.index_wrong_dim = InMemoryIndex(query_encoder=None)
+        self.early_stopping_index = InMemoryIndex(
+            LambdaEncoder(lambda q: np.array([10, 10])), mode=Mode.PASSAGE
+        )
         self.coalesced_indexes = [
             InMemoryIndex(mode=Mode.MAXP),
             InMemoryIndex(mode=Mode.MAXP),
@@ -398,6 +398,11 @@ class TestOnDiskIndex(TestIndex):
         )
         self.index_wrong_dim = OnDiskIndex(
             self.temp_dir / "index_wrong_dim.h5", query_encoder=None
+        )
+        self.early_stopping_index = OnDiskIndex(
+            self.temp_dir / "early_stopping_index.h5",
+            LambdaEncoder(lambda q: np.array([10, 10])),
+            mode=Mode.PASSAGE,
         )
         self.coalesced_indexes = [
             OnDiskIndex(self.temp_dir / "coalesced_index_1.h5", mode=Mode.MAXP),

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -10,7 +10,7 @@ from fast_forward.indexer import Indexer
 class TestIndexer(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.index = InMemoryIndex(16)
+        self.index = InMemoryIndex()
         self.indexer = Indexer(
             self.index, LambdaEncoder(lambda q: np.zeros(shape=(16,))), batch_size=2
         )

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -1,0 +1,54 @@
+import unittest
+
+import numpy as np
+
+from fast_forward.quantizer import Quantizer
+from fast_forward.quantizer.nanopq import NanoPQ
+
+
+class TestNanoPQ(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.quantizer = NanoPQ(8, 256)
+        self.quantizer_trained = NanoPQ(8, 256)
+        self.quantizer_trained.fit(
+            np.random.normal(size=(2**10, 768)).astype(np.float32)
+        )
+
+    def test_properties(self):
+        self.assertEqual((None, 8), self.quantizer.dims)
+        self.assertEqual(np.uint8, self.quantizer.dtype)
+        self.assertFalse(self.quantizer._trained)
+
+        self.assertEqual((768, 8), self.quantizer_trained.dims)
+        self.assertEqual(np.uint8, self.quantizer_trained.dtype)
+        self.assertTrue(self.quantizer_trained._trained)
+
+    def test_encoding_decoding(self):
+        inputs = np.random.normal(size=(8, 768)).astype(np.float32)
+        encoded = self.quantizer_trained.encode(inputs)
+        self.assertEqual(encoded.shape, (8, 8))
+        self.assertEqual(encoded.dtype, np.uint8)
+        decoded = self.quantizer_trained.decode(encoded)
+        self.assertEqual(decoded.shape, inputs.shape)
+
+    def test_serialization(self):
+        for q in (self.quantizer, self.quantizer_trained):
+            q_loaded = Quantizer.deserialize(*q.serialize())
+
+            # nanopq implements __eq__
+            self.assertEqual(q._pq, q_loaded._pq)
+            self.assertEqual(q._trained, q_loaded._trained)
+
+    def test_errors(self):
+        # encoding before the quantizer is trained
+        with self.assertRaises(RuntimeError):
+            self.quantizer.encode(np.random.normal(size=(8, 768)).astype(np.float32))
+
+        # attaching to index before the quantizer is trained
+        with self.assertRaises(RuntimeError):
+            self.quantizer.set_attached()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds support for index compression via vector quantization:
- Base class/interface for quantizers is added.
- (Trained) quantizers are serialized and stored in the index itself.
- A simple product quantizer based on [nanopq](https://github.com/matsui528/nanopq) is implemented.
- API change: Index dimension is not required in Index constructors anymore but will instead be inferred from the first batch of vectors that's added to the index.