### PR TITLE
Extend Indexer class

### DIFF
--- a/fast_forward/docs/indexer.md
+++ b/fast_forward/docs/indexer.md
@@ -16,7 +16,7 @@ doc_encoder = TCTColBERTDocumentEncoder(
 The indexer can be created as follows:
 
 ```python
-indexer = Indexer(my_index, doc_encoder, batch_size=8)
+indexer = Indexer(my_index, doc_encoder, encoder_batch_size=8)
 ```
 
 `fast_forward.indexer.Indexer.from_dicts` consumes an iterator that yields dictionaries:
@@ -28,3 +28,18 @@ def docs_iter():
 
 indexer.from_dicts(docs_iter())
 ```
+
+Additionally, indexers can be used to automatically fit and attach a quantizer during indexing. In this example, a quantized version (`target_index`) of an existing index (`source_index`) is created:
+
+```python
+from fast_forward.quantizer.nanopq import NanoPQ
+
+Indexer(
+    target_index,
+    quantizer=NanoPQ(8, 256),
+    batch_size=2**16,
+    quantizer_fit_batches=2,
+).from_index(source_index)
+```
+
+Here, the first two batches (of size $2ˆ{16}$) are buffered and used to fit the quantizer.

--- a/fast_forward/docs/indexer.md
+++ b/fast_forward/docs/indexer.md
@@ -1,4 +1,4 @@
-The `fast_forward.indexer.Indexer` class is a utility for indexing a collection. If the size of the collection is known in advace, it can be specified when the index is created in order to avoid subsequent resizing operations:
+The `fast_forward.indexer.Indexer` class is a utility for indexing a collection. If the size of the collection is known in advance, it can be specified when the index is created in order to avoid subsequent resizing operations:
 
 ```python
 my_index = OnDiskIndex(Path("my_index.h5"), init_size=1000000)
@@ -19,12 +19,12 @@ The indexer can be created as follows:
 indexer = Indexer(my_index, doc_encoder, batch_size=8)
 ```
 
-`fast_forward.indexer.Indexer.index_dicts` consumes an iterator that yields dictionaries:
+`fast_forward.indexer.Indexer.from_dicts` consumes an iterator that yields dictionaries:
 
 ```python
 def docs_iter():
     for doc in my_corpus:
         yield {"doc_id": doc.get_doc_id(), "text": doc.get_text()}
 
-indexer.index_dicts(docs_iter())
+indexer.from_dicts(docs_iter())
 ```

--- a/fast_forward/indexer.py
+++ b/fast_forward/indexer.py
@@ -35,7 +35,7 @@ class Indexer(object):
         Args:
             index (Index): The target index.
             encoder (Encoder, optional): Document/passage encoder. Defaults to None.
-            encoder_batch_size (int, optional): Encoder batch size. Defaults to 256.
+            encoder_batch_size (int, optional): Encoder batch size. Defaults to 128.
             batch_size (int, optional): How many vectors to add to the index at once. Defaults to 2**16.
             quantizer (Quantizer, optional): A quantizer to be fit and attached to the index. Defaults to None.
             quantizer_fit_batches (int, optional): How many of the first batches to use to fit the quantizer. Defaults to 1.

--- a/fast_forward/indexer.py
+++ b/fast_forward/indexer.py
@@ -25,7 +25,7 @@ class Indexer(object):
         self._encoder = encoder
         self._batch_size = batch_size
 
-    def index_dicts(self, data: Iterable[Dict[str, str]]) -> None:
+    def from_dicts(self, data: Iterable[Dict[str, str]]) -> None:
         """Index data from dictionaries.
 
         The dictionaries should have the key "text" and at least one of "doc_id" and "psg_id".

--- a/fast_forward/indexer.py
+++ b/fast_forward/indexer.py
@@ -2,30 +2,95 @@
 .. include:: docs/indexer.md
 """
 
+import logging
 from typing import Dict, Iterable
 
+import numpy as np
 from tqdm import tqdm
 
 from fast_forward.encoder import Encoder
-from fast_forward.index import Index
+from fast_forward.index import IDSequence, Index
+from fast_forward.quantizer import Quantizer
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Indexer(object):
     """Utility class for indexing collections."""
 
     def __init__(
-        self, index: Index, encoder: Encoder = None, batch_size: int = 32
+        self,
+        index: Index,
+        encoder: Encoder = None,
+        batch_size: int = 32,
+        quantizer: Quantizer = None,
+        quantizer_fit_batches: int = 2**8,
     ) -> None:
-        """Constructor.
+        """Instantiate an indexer.
 
         Args:
-            index (Index): The index to add the collection to.
+            index (Index): The target index.
             encoder (Encoder, optional): Document/passage encoder. Defaults to None.
             batch_size (int, optional): How many items to process at once. Defaults to 32.
+            quantizer (Quantizer, optional): A quantizer to be trained and attached to the index. Defaults to None.
+            quantizer_fit_batches (int, optional): How many of the first batches to use to fit the quantizer. Defaults to 2**8.
         """
         self._index = index
         self._encoder = encoder
         self._batch_size = batch_size
+        self._quantizer = quantizer
+        self._quantizer_fit_batches = quantizer_fit_batches
+
+        if quantizer is not None:
+            self._buf_vectors, self._buf_doc_ids, self._buf_psg_ids = [], [], []
+            LOGGER.warning(
+                "quantizer is set, inputs will be buffered and index will remain empty until the quantizer has been fit"
+            )
+
+    def _index_batch(
+        self,
+        vectors: np.ndarray,
+        doc_ids: IDSequence = None,
+        psg_ids: IDSequence = None,
+    ) -> None:
+        """Add a batch to the index.
+
+        If this indexer has a quantizer to be trained, the inputs will be buffered until the desired amount of data for fitting
+        has been obtained. Afterwards, the quantizer is fit and attached to the index, and all buffered inputs are added at once.
+
+        Args:
+            vectors (np.ndarray): The vectors.
+            doc_ids (IDSequence, optional): Corresponding document IDs. Defaults to None.
+            psg_ids (IDSequence, optional): Corresponding passage IDs. Defaults to None.
+        """
+        if self._quantizer is None:
+            self._index.add(vectors, doc_ids, psg_ids)
+            return
+
+        self._buf_vectors.append(vectors)
+        self._buf_doc_ids.append(doc_ids)
+        self._buf_psg_ids.append(psg_ids)
+
+        if len(self._buf_vectors) >= self._quantizer_fit_batches:
+            LOGGER.info(
+                "fitting quantizer (%s batches of size %s)",
+                len(self._buf_vectors),
+                self._batch_size,
+            )
+
+            self._quantizer.fit(np.concatenate(self._buf_vectors))
+            self._index.quantizer = self._quantizer
+            self._quantizer = None
+
+            LOGGER.info("adding buffered vectors to index")
+            for vectors, doc_ids, psg_ids in zip(
+                self._buf_vectors, self._buf_doc_ids, self._buf_psg_ids
+            ):
+                self._index.add(vectors, doc_ids, psg_ids)
+
+            del self._buf_vectors
+            del self._buf_doc_ids
+            del self._buf_psg_ids
 
     def from_dicts(self, data: Iterable[Dict[str, str]]) -> None:
         """Index data from dictionaries.
@@ -48,11 +113,13 @@ class Indexer(object):
             psg_ids.append(d.get("psg_id"))
 
             if len(texts) == self._batch_size:
-                self._index.add(self._encoder(texts), doc_ids=doc_ids, psg_ids=psg_ids)
+                self._index_batch(
+                    self._encoder(texts), doc_ids=doc_ids, psg_ids=psg_ids
+                )
                 texts, doc_ids, psg_ids = [], [], []
 
         if len(texts) > 0:
-            self._index.add(self._encoder(texts), doc_ids=doc_ids, psg_ids=psg_ids)
+            self._index_batch(self._encoder(texts), doc_ids=doc_ids, psg_ids=psg_ids)
 
     def from_index(self, index: Index) -> None:
         """Transfer vectors and IDs from another index.
@@ -61,4 +128,4 @@ class Indexer(object):
             index (Index): The source index.
         """
         for vectors, doc_ids, psg_ids in tqdm(index.batch_iter(self._batch_size)):
-            self._index.add(vectors, doc_ids, psg_ids)
+            self._index_batch(vectors, doc_ids, psg_ids)

--- a/fast_forward/indexer.py
+++ b/fast_forward/indexer.py
@@ -166,6 +166,8 @@ class Indexer(object):
     def from_index(self, index: Index) -> None:
         """Transfer vectors and IDs from another index.
 
+        If the source index uses quantized representations, the vectors are reconstructed first.
+
         Args:
             index (Index): The source index.
         """

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -11,7 +11,10 @@ class TestIndexer(unittest.TestCase):
     def setUp(self):
         self.index = InMemoryIndex()
         self.indexer = Indexer(
-            self.index, LambdaEncoder(lambda q: np.zeros(shape=(16,))), batch_size=2
+            self.index,
+            LambdaEncoder(lambda q: np.zeros(shape=(16,))),
+            encoder_batch_size=2,
+            batch_size=4,
         )
 
     def test_from_dicts(self):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -8,31 +8,41 @@ from fast_forward.indexer import Indexer
 
 
 class TestIndexer(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.index = InMemoryIndex()
-        cls.indexer = Indexer(
-            cls.index, LambdaEncoder(lambda q: np.zeros(shape=(16,))), batch_size=2
+    def setUp(self):
+        self.index = InMemoryIndex()
+        self.indexer = Indexer(
+            self.index, LambdaEncoder(lambda q: np.zeros(shape=(16,))), batch_size=2
         )
 
     def test_from_dicts(self):
-        self.indexer.from_dicts(
-            [
-                {"text": "123", "doc_id": "d1", "psg_id": "d1_p1"},
-                {"text": "234", "doc_id": "d1", "psg_id": "d1_p2"},
-                {"text": "456", "doc_id": "d1", "psg_id": "d1_p3"},
-                {"text": "567", "doc_id": "d2", "psg_id": "d2_p1"},
-                {"text": "678", "doc_id": "d3", "psg_id": "d3_p1"},
-                {"text": "890", "doc_id": "d4"},
-                {"text": "901", "psg_id": "d5_p1"},
-            ]
-        )
+        dicts = [
+            {"text": "123", "doc_id": "d1", "psg_id": "d1_p1"},
+            {"text": "234", "doc_id": "d1", "psg_id": "d1_p2"},
+            {"text": "456", "doc_id": "d1", "psg_id": "d1_p3"},
+            {"text": "567", "doc_id": "d2", "psg_id": "d2_p1"},
+            {"text": "678", "doc_id": "d3", "psg_id": "d3_p1"},
+            {"text": "890", "doc_id": "d4"},
+            {"text": "901", "psg_id": "d5_p1"},
+        ]
+        self.indexer.from_dicts(dicts)
         self.assertEqual(7, len(self.index))
         self.assertEqual(set(("d1", "d2", "d3", "d4")), self.index.doc_ids)
         self.assertEqual(
             set(("d1_p1", "d1_p2", "d1_p3", "d2_p1", "d3_p1", "d5_p1")),
             self.index.psg_ids,
         )
+
+        with self.assertRaises(RuntimeError):
+            Indexer(self.index, encoder=None).from_dicts(dicts)
+
+    def test_from_index(self):
+        source_index = InMemoryIndex()
+        source_index.add(
+            np.zeros((16, 16), dtype=np.float32), doc_ids=[f"d{i}" for i in range(16)]
+        )
+        self.indexer.from_index(source_index)
+        self.assertEqual(source_index.doc_ids, self.index.doc_ids)
+        self.assertEqual(16, len(self.index))
 
 
 if __name__ == "__main__":

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -5,13 +5,14 @@ import numpy as np
 from fast_forward.encoder import LambdaEncoder
 from fast_forward.index.memory import InMemoryIndex
 from fast_forward.indexer import Indexer
+from fast_forward.quantizer.nanopq import NanoPQ
 
 
 class TestIndexer(unittest.TestCase):
     def setUp(self):
-        self.index = InMemoryIndex()
+        self.target_index = InMemoryIndex()
         self.indexer = Indexer(
-            self.index,
+            self.target_index,
             LambdaEncoder(lambda q: np.zeros(shape=(16,))),
             encoder_batch_size=2,
             batch_size=4,
@@ -28,15 +29,15 @@ class TestIndexer(unittest.TestCase):
             {"text": "901", "psg_id": "d5_p1"},
         ]
         self.indexer.from_dicts(dicts)
-        self.assertEqual(7, len(self.index))
-        self.assertEqual(set(("d1", "d2", "d3", "d4")), self.index.doc_ids)
+        self.assertEqual(7, len(self.target_index))
+        self.assertEqual(set(("d1", "d2", "d3", "d4")), self.target_index.doc_ids)
         self.assertEqual(
             set(("d1_p1", "d1_p2", "d1_p3", "d2_p1", "d3_p1", "d5_p1")),
-            self.index.psg_ids,
+            self.target_index.psg_ids,
         )
 
         with self.assertRaises(RuntimeError):
-            Indexer(self.index, encoder=None).from_dicts(dicts)
+            Indexer(self.target_index, encoder=None).from_dicts(dicts)
 
     def test_from_index(self):
         source_index = InMemoryIndex()
@@ -44,8 +45,34 @@ class TestIndexer(unittest.TestCase):
             np.zeros((16, 16), dtype=np.float32), doc_ids=[f"d{i}" for i in range(16)]
         )
         self.indexer.from_index(source_index)
-        self.assertEqual(source_index.doc_ids, self.index.doc_ids)
-        self.assertEqual(16, len(self.index))
+        self.assertEqual(source_index.doc_ids, self.target_index.doc_ids)
+        self.assertEqual(16, len(self.target_index))
+
+    def test_quantizer(self):
+        for quantizer_fit_batches in (1, 2):
+            target_index = InMemoryIndex()
+            indexer = Indexer(
+                target_index,
+                encoder=LambdaEncoder(
+                    lambda q: np.random.normal(size=(32,)).astype(np.float32)
+                ),
+                quantizer=NanoPQ(4, 8),
+                batch_size=16,
+                quantizer_fit_batches=quantizer_fit_batches,
+            )
+            indexer.from_dicts(
+                [{"text": f"text_{i}", "doc_id": f"d{i}"} for i in range(64)]
+            )
+            self.assertTrue(target_index.quantizer._trained)
+
+        with self.assertRaises(ValueError):
+            quantizer = NanoPQ(4, 8)
+            quantizer.fit(np.random.normal(size=(64, 64)).astype(np.float32))
+            Indexer(self.target_index, quantizer=quantizer)
+
+        with self.assertRaises(ValueError):
+            self.target_index.add(np.zeros(shape=(8, 16), dtype=np.float32))
+            Indexer(self.target_index, quantizer=NanoPQ(4, 8))
 
 
 if __name__ == "__main__":

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -9,14 +9,14 @@ from fast_forward.indexer import Indexer
 
 class TestIndexer(unittest.TestCase):
     @classmethod
-    def setUpClass(self):
-        self.index = InMemoryIndex()
-        self.indexer = Indexer(
-            self.index, LambdaEncoder(lambda q: np.zeros(shape=(16,))), batch_size=2
+    def setUpClass(cls):
+        cls.index = InMemoryIndex()
+        cls.indexer = Indexer(
+            cls.index, LambdaEncoder(lambda q: np.zeros(shape=(16,))), batch_size=2
         )
 
-    def test_index_dicts(self):
-        self.indexer.index_dicts(
+    def test_from_dicts(self):
+        self.indexer.from_dicts(
             [
                 {"text": "123", "doc_id": "d1", "psg_id": "d1_p1"},
                 {"text": "234", "doc_id": "d1", "psg_id": "d1_p2"},

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -71,10 +71,10 @@ class TestNanoOPQ(TestQuantizer):
     __test__ = True
 
     @classmethod
-    def setUpClass(self):
-        self.quantizer = NanoOPQ(8, 256)
-        self.quantizer_trained = NanoOPQ(8, 256)
-        self.quantizer_trained.fit(
+    def setUpClass(cls):
+        cls.quantizer = NanoOPQ(8, 256)
+        cls.quantizer_trained = NanoOPQ(8, 256)
+        cls.quantizer_trained.fit(
             np.random.normal(size=(2**10, 768)).astype(np.float32)
         )
 


### PR DESCRIPTION
- Make encoder in Indexer optional
- Allow transferring vectors and IDs from a source index to a target index
- Add the option to automatically fit a quantizer during indexing
- Separate `batch_size` and `encoder_batch_size`