### PR TITLE
Memmap

### DIFF
--- a/src/fast_forward/index/disk.py
+++ b/src/fast_forward/index/disk.py
@@ -29,7 +29,7 @@ class OnDiskIndex(Index):
     [h5py limitation](https://docs.h5py.org/en/latest/high/dataset.html#fancy-indexing).
 
     If `use_mmap` is set to `True`, the vectors on disk are accessed using memory maps,
-    which is usually faster.
+    which is usually faster. In this case, `max_indexing_size` has no effect.
     """
 
     def __init__(
@@ -39,8 +39,8 @@ class OnDiskIndex(Index):
         quantizer: Quantizer | None = None,
         mode: Mode = Mode.MAXP,
         encoder_batch_size: int = 32,
-        init_size: int = 2**14,
-        chunk_size: int = 2**14,
+        init_size: int = 2**16,
+        chunk_size: int = 2**16,
         max_id_length: int = 8,
         use_mmap: bool = False,
         overwrite: bool = False,
@@ -57,7 +57,7 @@ class OnDiskIndex(Index):
         :param chunk_size: Size of chunks (HDF5).
         :param max_id_length:
             Maximum length of document and passage IDs (number of characters).
-        :param use_mmap: Use memory maps for retrieval of vectors if possible.
+        :param use_mmap: Use memory maps for retrieval of vectors.
         :param overwrite: Overwrite index file if it exists.
         :param max_indexing_size:
             Maximum number of vectors to retrieve from the HDF5 dataset at once.

--- a/src/fast_forward/index/disk.py
+++ b/src/fast_forward/index/disk.py
@@ -238,9 +238,10 @@ class OnDiskIndex(Index):
             num_cur_vectors = cast("int", fp.attrs["num_vectors"])
             space_left = capacity - num_cur_vectors
             if num_new_vecs > space_left:
-                # resize based on chunk size
+                # resize based on chunk size, i.e., allocate as many chunks as necessary
+                # for the new data
                 new_size = (
-                    int((num_cur_vectors + num_new_vecs) / self._chunk_size) + 1
+                    int((num_cur_vectors + num_new_vecs) / self._chunk_size + 0.5)
                 ) * self._chunk_size
                 LOGGER.debug("resizing index from %s to %s", capacity, new_size)
                 for ds in ("vectors", "doc_ids", "psg_ids"):

--- a/src/fast_forward/index/disk.py
+++ b/src/fast_forward/index/disk.py
@@ -94,6 +94,7 @@ class OnDiskIndex(Index):
     def _get_mmap_indexer(self) -> ChunkIndexer:
         """Create and return a chunk indexer using memory-mapped arrays.
 
+        :raises RuntimeError: When the dataset is not chunked in the required way.
         :return: The chunk indexer.
         """
         if self._mmap_indexer is None:

--- a/src/fast_forward/index/memory.py
+++ b/src/fast_forward/index/memory.py
@@ -26,8 +26,8 @@ class InMemoryIndex(Index):
         quantizer: "Quantizer | None" = None,
         mode: Mode = Mode.MAXP,
         encoder_batch_size: int = 32,
-        init_size: int = 2**14,
-        alloc_size: int = 2**14,
+        init_size: int = 2**16,
+        alloc_size: int = 2**16,
     ) -> None:
         """Create an index in memory.
 

--- a/src/fast_forward/index/memory.py
+++ b/src/fast_forward/index/memory.py
@@ -6,9 +6,10 @@ import numpy as np
 from tqdm import tqdm
 
 from fast_forward.index.base import IDSequence, Index, Mode
+from fast_forward.index.util import ChunkIndexer
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Sequence
+    from collections.abc import Iterable, Iterator
 
     from fast_forward.encoder.base import Encoder
     from fast_forward.quantizer import Quantizer
@@ -34,15 +35,18 @@ class InMemoryIndex(Index):
         :param quantizer: The quantizer to use.
         :param mode: The ranking mode.
         :param encoder_batch_size: Batch size for the query encoder.
-        :param init_size: Initial index size (number of vectors).
-        :param alloc_size: Shard size (number of vectors) allocated when index is full.
+        :param init_size: Size of initial chunk (number of vectors).
+        :param alloc_size: Size of additionally allocated chunks (number of vectors).
         """
-        self._shards = []
+        self._chunks = []
         self._init_size = init_size
         self._alloc_size = alloc_size
-        self._idx_in_cur_shard = 0
+        self._idx_in_cur_chunk = 0
         self._doc_id_to_idx = defaultdict(list)
         self._psg_id_to_idx = {}
+        self._chunk_indexer = ChunkIndexer(
+            self._chunks, self._doc_id_to_idx, self._psg_id_to_idx
+        )
 
         super().__init__(
             query_encoder=query_encoder,
@@ -52,18 +56,18 @@ class InMemoryIndex(Index):
         )
 
     def _get_num_vectors(self) -> int:
-        # account for the fact that the first shard might be larger
-        if len(self._shards) < 2:
-            return self._idx_in_cur_shard
+        # account for the fact that the first chunk might be larger
+        if len(self._chunks) < 2:
+            return self._idx_in_cur_chunk
         return (
-            self._shards[0].shape[0]
-            + (len(self._shards) - 2) * self._alloc_size
-            + self._idx_in_cur_shard
+            self._chunks[0].shape[0]
+            + (len(self._chunks) - 2) * self._alloc_size
+            + self._idx_in_cur_chunk
         )
 
     def _get_internal_dim(self) -> int | None:
-        if len(self._shards) > 0:
-            return self._shards[0].shape[-1]
+        if len(self._chunks) > 0:
+            return self._chunks[0].shape[-1]
         return None
 
     def _add(
@@ -72,9 +76,9 @@ class InMemoryIndex(Index):
         doc_ids: IDSequence,
         psg_ids: IDSequence,
     ) -> None:
-        # if this is the first call to _add, no shards exist
-        if len(self._shards) == 0:
-            self._shards.append(
+        # if this is the first call to _add, no chunks exist
+        if len(self._chunks) == 0:
+            self._chunks.append(
                 np.zeros((self._init_size, vectors.shape[-1]), dtype=vectors.dtype)
             )
 
@@ -90,40 +94,41 @@ class InMemoryIndex(Index):
                 raise RuntimeError(f"Passage ID {psg_id} already exists.")
             self._psg_id_to_idx[psg_id] = i
 
-        # add vectors to shards
+        # add vectors to chunks
         added = 0
         num_vectors = vectors.shape[0]
         while added < num_vectors:
-            cur_shard_size, dim = self._shards[-1].shape
+            cur_chunk_size, dim = self._chunks[-1].shape
 
-            # if current shard is full, add a new one
-            if self._idx_in_cur_shard == cur_shard_size:
-                LOGGER.debug("adding new shard")
-                self._shards.append(np.zeros((self._alloc_size, dim)))
-                self._idx_in_cur_shard = 0
-                cur_shard_size = self._alloc_size
+            # if current chunk is full, add a new one
+            if self._idx_in_cur_chunk == cur_chunk_size:
+                LOGGER.debug("adding new chunk")
+                self._chunks.append(np.zeros((self._alloc_size, dim)))
+                self._idx_in_cur_chunk = 0
+                cur_chunk_size = self._alloc_size
 
             to_add = min(
                 num_vectors - added,
-                cur_shard_size,
-                cur_shard_size - self._idx_in_cur_shard,
+                cur_chunk_size,
+                cur_chunk_size - self._idx_in_cur_chunk,
             )
-            self._shards[-1][
-                self._idx_in_cur_shard : self._idx_in_cur_shard + to_add
+            self._chunks[-1][
+                self._idx_in_cur_chunk : self._idx_in_cur_chunk + to_add
             ] = vectors[added : added + to_add]
             added += to_add
-            self._idx_in_cur_shard += to_add
+            self._idx_in_cur_chunk += to_add
 
     def consolidate(self) -> None:
-        """Combine all shards of the index in one contiguous section in the memory."""
-        # combine all shards up to the last one entirely, and take only whats in use of
+        """Combine all chunks of the index in one contiguous section in the memory."""
+        # combine all chunks up to the last one entirely, and take only whats in use of
         # the last one
-        self._shards = [
+        self._chunks = [
             np.concatenate(
-                self._shards[:-1] + [self._shards[-1][: self._idx_in_cur_shard]]
+                self._chunks[:-1] + [self._chunks[-1][: self._idx_in_cur_chunk]]
             )
         ]
-        self._idx_in_cur_shard = self._shards[0].shape[0]
+        self._idx_in_cur_chunk = self._chunks[0].shape[0]
+        self._chunk_indexer._chunks = self._chunks
 
     def _get_doc_ids(self) -> set[str]:
         return set(self._doc_id_to_idx.keys())
@@ -131,70 +136,8 @@ class InMemoryIndex(Index):
     def _get_psg_ids(self) -> set[str]:
         return set(self._psg_id_to_idx.keys())
 
-    def _index(self, idxs: "Sequence[int]") -> np.ndarray:
-        """Return vectors from the internal array(s).
-
-        This method retrieves vectors from the correct shards (if there are any).
-
-        :param idxs: Indices to return vectors for.
-        :return: The vectors in the same order as the provided indices.
-        """
-        if len(idxs) == 0:
-            return np.array([])
-
-        # if there is no sharding, simply use numpy indexing
-        if len(self._shards) == 1:
-            return self._shards[0][idxs]
-
-        # otherwise, group indexes by shard and index each shared individually
-        items_by_shard = defaultdict(lambda: ([], []))
-        for i, idx in enumerate(idxs):
-            # the first shard might be larger
-            if idx < self._shards[0].shape[0]:
-                shard_idx = 0
-                idx_in_shard = idx
-            else:
-                idx_ = idx - self._shards[0].shape[0]
-                shard_idx = int(idx_ / self._alloc_size) + 1
-                idx_in_shard = idx_ % self._alloc_size
-            items_by_shard[shard_idx][0].append(idx_in_shard)
-            items_by_shard[shard_idx][1].append(i)
-
-        result = []
-        ordering = []
-        for shard_idx, (idxs_in_shard, i_) in items_by_shard.items():
-            result.append(self._shards[shard_idx][idxs_in_shard])
-            ordering.extend(i_)
-
-        return np.concatenate(result)[np.argsort(ordering)]
-
-    def _get_idxs(self, id: str) -> list[int]:
-        """Find the internal array indices for a document/passage ID.
-
-        Takes ranking mode into account.
-
-        :param id: The ID to return the indices for.
-        :raises IndexError: When the ID cannot be found in the index.
-        :return: The internal array indices.
-        """
-        if self.mode in (Mode.MAXP, Mode.AVEP):
-            return self._doc_id_to_idx.get(id, [])
-        if self.mode == Mode.FIRSTP:
-            return self._doc_id_to_idx.get(id, [])[:1]
-
-        psg_idx = self._psg_id_to_idx.get(id)
-        return [] if psg_idx is None else [psg_idx]
-
     def _get_vectors(self, ids: "Iterable[str]") -> tuple[np.ndarray, list[str]]:
-        idxs = []
-        ids_ = []
-        for id in ids:
-            cur_idxs = self._get_idxs(id)
-            if len(cur_idxs) == 0:
-                raise IndexError(f"ID {id} not found in the index.")
-            idxs.extend(cur_idxs)
-            ids_.extend([id] * len(cur_idxs))
-        return self._index(idxs), ids_
+        return self._chunk_indexer(ids, self.mode)
 
     def _batch_iter(
         self, batch_size: int
@@ -211,9 +154,27 @@ class InMemoryIndex(Index):
 
         num_vectors = len(self)
         for i in range(0, num_vectors, batch_size):
-            idxs = range(i, min(i + batch_size, num_vectors))
+            j = min(i + batch_size, num_vectors)
+
+            # the current batch is between i (incl.) and j (excl.)
+            i_chunk_idx, i_idx_in_chunk = self._chunk_indexer._get_chunk_indices(i)
+            j_chunk_idx, j_idx_in_chunk = self._chunk_indexer._get_chunk_indices(j - 1)
+
+            arrays = []
+
+            # if the batch spans multiple chunks, collect them in a list
+            while i_chunk_idx < j_chunk_idx:
+                arrays.append(self._chunks[i_chunk_idx][i_idx_in_chunk:])
+                i_chunk_idx += 1
+                i_idx_in_chunk = 0
+
+            # now i_chunk_idx == j_chunk_idx
+            arrays.append(
+                self._chunks[i_chunk_idx][i_idx_in_chunk : j_idx_in_chunk + 1]
+            )
+
             yield (
-                self._index(idxs),
-                list(map(idx_to_doc_id.get, idxs)),
-                list(map(idx_to_psg_id.get, idxs)),
+                np.concatenate(arrays),
+                list(map(idx_to_doc_id.get, range(i, j))),
+                list(map(idx_to_psg_id.get, range(i, j))),
             )

--- a/src/fast_forward/index/util.py
+++ b/src/fast_forward/index/util.py
@@ -1,0 +1,104 @@
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from fast_forward.index.base import Mode
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+class ChunkIndexer:
+    """Utility class for retrieving vectors from chunked indexes."""
+
+    def __init__(
+        self,
+        chunks: list[np.ndarray],
+        doc_id_to_idx: dict[str, list[int]],
+        psg_id_to_idx: dict[str, int],
+    ) -> None:
+        """Create a chunk indexer.
+
+        The first chunk may have a different size than the others.
+
+        :param chunks: A list of chunks.
+        :param doc_id_to_idx: Document IDs mapped to non-chunked indices.
+        :param psg_id_to_idx: Passage IDs mapped to non-chunked indices.
+        """
+        self._chunks = chunks
+        self._doc_id_to_idx = doc_id_to_idx
+        self._psg_id_to_idx = psg_id_to_idx
+
+    def _get_indices(self, id: str, mode: Mode) -> list[int]:
+        """Find the internal array indices for a document/passage ID.
+
+        :param id: The ID to return the indices for.
+        :param mode: The ranking mode.
+        :raises IndexError: When the ID cannot be found in the index.
+        :return: The internal array indices.
+        """
+        if mode in (Mode.MAXP, Mode.AVEP):
+            return self._doc_id_to_idx.get(id, [])
+        if mode == Mode.FIRSTP:
+            return self._doc_id_to_idx.get(id, [])[:1]
+
+        psg_idx = self._psg_id_to_idx.get(id)
+        return [] if psg_idx is None else [psg_idx]
+
+    def _get_chunk_indices(self, idx: int) -> tuple[int, int]:
+        """Given an index, compute the chunk index and index within that chunk.
+
+        The input index may be in `[0, N]`, where `N` is the total number of vectors.
+
+        :param idx: The input index.
+        :return: Chunk index and index within that chunk.
+        """
+        # the first chunk might be larger
+        if idx < self._chunks[0].shape[0]:
+            return 0, idx
+
+        idx_ = idx - self._chunks[0].shape[0]
+        return (
+            int(idx_ / self._chunks[1].shape[0]) + 1,
+            idx_ % self._chunks[1].shape[0],
+        )
+
+    def __call__(
+        self, ids: "Iterable[str]", mode: Mode
+    ) -> tuple[np.ndarray, list[str]]:
+        """Retrieve vectors for the given IDs from the chunks.
+
+        :param ids: IDs to return vectors for.
+        :raises IndexError: When the ID cannot be found in the index.
+        :return: The vectors and corresponding IDs.
+        """
+        indices = []
+        ids_ = []
+        for id in ids:
+            cur_indices = self._get_indices(id, mode)
+            if len(cur_indices) == 0:
+                raise IndexError(f"ID {id} not found in the index.")
+            indices.extend(cur_indices)
+            ids_.extend([id] * len(cur_indices))
+
+        if len(indices) == 0:
+            return np.array([]), []
+
+        if len(self._chunks) == 1:
+            return self._chunks[0][indices], ids_
+
+        # group indexes by chunk and index each chunk individually
+        items_by_chunk = defaultdict(lambda: ([], []))
+        for i, idx in enumerate(indices):
+            chunk_idx, idx_in_chunk = self._get_chunk_indices(idx)
+            items_by_chunk[chunk_idx][0].append(idx_in_chunk)
+            items_by_chunk[chunk_idx][1].append(i)
+
+        result = []
+        ordering = []
+        for chunk_idx, (idx_in_chunk, i_) in items_by_chunk.items():
+            result.append(self._chunks[chunk_idx][idx_in_chunk])
+            ordering.extend(i_)
+
+        return np.concatenate(result)[np.argsort(ordering)], ids_

--- a/src/fast_forward/index/util.py
+++ b/src/fast_forward/index/util.py
@@ -94,7 +94,6 @@ class ChunkIndexer:
 
         if len(indices) == 0:
             return np.array([]), []
-
         if len(self._chunks) == 1:
             return self._chunks[0][indices], ids_
 
@@ -103,12 +102,12 @@ class ChunkIndexer:
         for i, idx in enumerate(indices):
             chunk_idx, idx_in_chunk = self._get_chunk_indices(idx)
             items_by_chunk[chunk_idx][0].append(idx_in_chunk)
-            items_by_chunk[chunk_idx][1].append(i)
+            items_by_chunk[chunk_idx][1].append(ids_[i])
 
         result = []
-        ordering = []
-        for chunk_idx, (idx_in_chunk, i_) in items_by_chunk.items():
+        out_ids = []
+        for chunk_idx, (idx_in_chunk, ids_in_chunk) in items_by_chunk.items():
             result.append(self._chunks[chunk_idx][idx_in_chunk])
-            ordering.extend(i_)
+            out_ids.extend(ids_in_chunk)
 
-        return np.concatenate(result)[np.argsort(ordering)], ids_
+        return np.concatenate(result), out_ids

--- a/src/fast_forward/index/util.py
+++ b/src/fast_forward/index/util.py
@@ -38,7 +38,7 @@ class ChunkIndexer:
 
     def __init__(
         self,
-        chunks: list[np.ndarray],
+        chunks: list[np.ndarray] | list[np.memmap],
         doc_id_to_idx: dict[str, list[int]],
         psg_id_to_idx: dict[str, int],
     ) -> None:

--- a/src/fast_forward/index/util.py
+++ b/src/fast_forward/index/util.py
@@ -99,10 +99,10 @@ class ChunkIndexer:
 
         # group indexes by chunk and index each chunk individually
         items_by_chunk = defaultdict(lambda: ([], []))
-        for i, idx in enumerate(indices):
+        for idx, id in zip(indices, ids_):
             chunk_idx, idx_in_chunk = self._get_chunk_indices(idx)
             items_by_chunk[chunk_idx][0].append(idx_in_chunk)
-            items_by_chunk[chunk_idx][1].append(ids_[i])
+            items_by_chunk[chunk_idx][1].append(id)
 
         result = []
         out_ids = []

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -437,44 +437,48 @@ class TestOnDiskIndex(TestIndex):
     def setUpClass(cls):
         cls.temp_dir = Path(tempfile.mkdtemp())
         cls.index = OnDiskIndex(
-            cls.temp_dir / "index.h5", init_size=32, chunk_size=32, use_mmap=False
+            cls.temp_dir / "index.h5", init_size=32, chunk_size=32, memory_mapped=False
         )
         cls.doc_psg_index = OnDiskIndex(
-            cls.temp_dir / "doc_psg_index.h5", DUMMY_ENCODER, use_mmap=False
+            cls.temp_dir / "doc_psg_index.h5", DUMMY_ENCODER, memory_mapped=False
         )
         cls.index_partial_ids = OnDiskIndex(
             cls.temp_dir / "index_partial_ids.h5",
             DUMMY_ENCODER,
-            use_mmap=False,
+            memory_mapped=False,
         )
         cls.doc_index = OnDiskIndex(
             cls.temp_dir / "doc_index.h5",
             DUMMY_ENCODER,
-            use_mmap=False,
+            memory_mapped=False,
         )
         cls.psg_index = OnDiskIndex(
             cls.temp_dir / "psg_index.h5",
             DUMMY_ENCODER,
-            use_mmap=False,
+            memory_mapped=False,
         )
         cls.index_no_enc = OnDiskIndex(
-            cls.temp_dir / "index_no_enc.h5", query_encoder=None, use_mmap=False
+            cls.temp_dir / "index_no_enc.h5", query_encoder=None, memory_mapped=False
         )
         cls.index_wrong_dim = OnDiskIndex(
-            cls.temp_dir / "index_wrong_dim.h5", query_encoder=None, use_mmap=False
+            cls.temp_dir / "index_wrong_dim.h5", query_encoder=None, memory_mapped=False
         )
         cls.early_stopping_index = OnDiskIndex(
             cls.temp_dir / "early_stopping_index.h5",
             LambdaEncoder(lambda q: np.array([10, 10])),
             mode=Mode.PASSAGE,
-            use_mmap=False,
+            memory_mapped=False,
         )
         cls.coalesced_indexes = [
             OnDiskIndex(
-                cls.temp_dir / "coalesced_index_1.h5", mode=Mode.MAXP, use_mmap=False
+                cls.temp_dir / "coalesced_index_1.h5",
+                mode=Mode.MAXP,
+                memory_mapped=False,
             ),
             OnDiskIndex(
-                cls.temp_dir / "coalesced_index_2.h5", mode=Mode.MAXP, use_mmap=False
+                cls.temp_dir / "coalesced_index_2.h5",
+                mode=Mode.MAXP,
+                memory_mapped=False,
             ),
         ]
         cls.iter_indexes = [
@@ -482,14 +486,16 @@ class TestOnDiskIndex(TestIndex):
                 cls.temp_dir / "iter_index_1.h5",
                 init_size=2,
                 chunk_size=2,
-                use_mmap=False,
+                memory_mapped=False,
             ),
-            OnDiskIndex(cls.temp_dir / "iter_index_2.h5", init_size=5, use_mmap=False),
+            OnDiskIndex(
+                cls.temp_dir / "iter_index_2.h5", init_size=5, memory_mapped=False
+            ),
         ]
         cls.quantized_index = OnDiskIndex(
             cls.temp_dir / "quantized_index.h5",
             quantizer=DUMMY_QUANTIZER,
-            use_mmap=False,
+            memory_mapped=False,
         )
         super(TestOnDiskIndex, cls).setUpClass()
 
@@ -622,13 +628,13 @@ class TestOnDiskIndex(TestIndex):
         vecs, ids = index._get_vectors(psg_ids)
         _test_vectors(vecs, ids, psg_reps, psg_ids)
 
-    def test_mmap(self):
+    def test_memory_mapped(self):
         index = OnDiskIndex(
             self.temp_dir / "mmap_index.h5",
             mode=Mode.PASSAGE,
             init_size=8,
             chunk_size=4,
-            use_mmap=True,
+            memory_mapped=True,
         )
         psg_reps = np.random.normal(size=(16, 16))
         psg_ids = [f"p{i}" for i in range(16)]

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -436,9 +436,7 @@ class TestOnDiskIndex(TestIndex):
     @classmethod
     def setUpClass(cls):
         cls.temp_dir = Path(tempfile.mkdtemp())
-        cls.index = OnDiskIndex(
-            cls.temp_dir / "index.h5", init_size=32, resize_min_val=32
-        )
+        cls.index = OnDiskIndex(cls.temp_dir / "index.h5", init_size=32, chunk_size=32)
         cls.doc_psg_index = OnDiskIndex(
             cls.temp_dir / "doc_psg_index.h5",
             DUMMY_ENCODER,
@@ -474,7 +472,7 @@ class TestOnDiskIndex(TestIndex):
             OnDiskIndex(
                 cls.temp_dir / "iter_index_1.h5",
                 init_size=2,
-                resize_min_val=2,
+                chunk_size=2,
             ),
             OnDiskIndex(cls.temp_dir / "iter_index_2.h5", init_size=5),
         ]


### PR DESCRIPTION
- Implement memory-mapped access to vectors in `OnDiskIndex` via `memory_mapped=True`
- Unify terminology ("chunks") for both index types
- `OnDiskIndex`: Rename `hdf5_chunk_size` to `chunk_size`, remove `min_resize_val`